### PR TITLE
feat: 添加直播统计功能

### DIFF
--- a/src/app/admin/live-stats/page.tsx
+++ b/src/app/admin/live-stats/page.tsx
@@ -1,0 +1,570 @@
+'use client';
+
+import { ChevronUp } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import React, { useCallback, useEffect, useState } from 'react';
+
+import { getAuthInfoFromBrowserCookie } from '@/lib/auth';
+import { LiveStatsResult } from '@/lib/types';
+
+import PageLayout from '@/components/PageLayout';
+
+const LiveStatsPage: React.FC = () => {
+  const router = useRouter();
+  const [statsData, setStatsData] = useState<LiveStatsResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedUsers, setExpandedUsers] = useState<Set<string>>(new Set());
+  const [authInfo, setAuthInfo] = useState<{
+    username?: string;
+    role?: string;
+  } | null>(null);
+  const [showBackToTop, setShowBackToTop] = useState(false);
+
+  // 检查用户权限
+  useEffect(() => {
+    const auth = getAuthInfoFromBrowserCookie();
+    if (!auth || !auth.username) {
+      router.push('/login');
+      return;
+    }
+
+    // 检查是否为管理员
+    if (auth.role !== 'admin' && auth.role !== 'owner') {
+      router.push('/');
+      return;
+    }
+
+    setAuthInfo(auth);
+  }, [router]);
+
+  // 时间格式化函数
+  const formatTime = (seconds: number): string => {
+    if (seconds === 0) return '00:00';
+
+    const hours = Math.floor(seconds / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+    const remainingSeconds = Math.round(seconds % 60);
+
+    if (hours === 0) {
+      return `${minutes.toString().padStart(2, '0')}:${remainingSeconds
+        .toString()
+        .padStart(2, '0')}`;
+    } else {
+      return `${hours.toString().padStart(2, '0')}:${minutes
+        .toString()
+        .padStart(2, '0')}:${remainingSeconds.toString().padStart(2, '0')}`;
+    }
+  };
+
+  const formatDateTime = (timestamp: number): string => {
+    if (!timestamp) return '未知时间';
+
+    const date = new Date(timestamp);
+    if (isNaN(date.getTime())) return '时间格式错误';
+
+    return date.toLocaleString('zh-CN', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+    });
+  };
+
+  // 获取统计数据
+  const fetchStats = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/admin/live-stats');
+
+      if (response.status === 401) {
+        router.push('/login');
+        return;
+      }
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || `HTTP ${response.status}`);
+      }
+
+      const data = await response.json();
+      setStatsData(data);
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : '获取直播统计失败';
+      setError(errorMessage);
+    } finally {
+      setLoading(false);
+    }
+  }, [router]);
+
+  // 处理刷新按钮点击
+  const handleRefreshClick = async () => {
+    await fetchStats();
+  };
+
+  // 切换用户详情展开状态
+  const toggleUserExpanded = (username: string) => {
+    setExpandedUsers((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(username)) {
+        newSet.delete(username);
+      } else {
+        newSet.add(username);
+      }
+      return newSet;
+    });
+  };
+
+  // 检查是否支持统计
+  const storageType =
+    typeof window !== 'undefined' &&
+    (window as Record<string, unknown>).RUNTIME_CONFIG?.STORAGE_TYPE
+      ? (
+          (window as Record<string, unknown>).RUNTIME_CONFIG as Record<
+            string,
+            unknown
+          >
+        ).STORAGE_TYPE
+      : 'localstorage';
+
+  useEffect(() => {
+    if (authInfo) {
+      fetchStats();
+    }
+  }, [authInfo, fetchStats]);
+
+  // 监听滚动位置，显示/隐藏回到顶部按钮
+  useEffect(() => {
+    const handleScroll = () => {
+      const scrollTop =
+        document.body.scrollTop || document.documentElement.scrollTop || 0;
+      setShowBackToTop(scrollTop > 300);
+    };
+
+    document.body.addEventListener('scroll', handleScroll, { passive: true });
+
+    return () => {
+      document.body.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+
+  // 返回顶部功能
+  const scrollToTop = () => {
+    try {
+      document.body.scrollTo({
+        top: 0,
+        behavior: 'smooth',
+      });
+    } catch (error) {
+      document.body.scrollTop = 0;
+    }
+  };
+
+  // 未授权时显示加载
+  if (!authInfo) {
+    return (
+      <PageLayout activePath='/admin/live-stats'>
+        <div className='text-center py-12'>
+          <div className='inline-flex items-center space-x-2 text-gray-600 dark:text-gray-400'>
+            <svg
+              className='w-6 h-6 animate-spin'
+              fill='none'
+              stroke='currentColor'
+              viewBox='0 0 24 24'
+            >
+              <path
+                strokeLinecap='round'
+                strokeLinejoin='round'
+                strokeWidth='2'
+                d='M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15'
+              />
+            </svg>
+            <span>检查权限中...</span>
+          </div>
+        </div>
+      </PageLayout>
+    );
+  }
+
+  if (loading) {
+    return (
+      <PageLayout activePath='/admin/live-stats'>
+        <div className='text-center py-12'>
+          <div className='inline-flex items-center space-x-2 text-gray-600 dark:text-gray-400'>
+            <svg
+              className='w-6 h-6 animate-spin'
+              fill='none'
+              stroke='currentColor'
+              viewBox='0 0 24 24'
+            >
+              <path
+                strokeLinecap='round'
+                strokeLinejoin='round'
+                strokeWidth='2'
+                d='M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15'
+              />
+            </svg>
+            <span>正在加载直播统计...</span>
+          </div>
+        </div>
+      </PageLayout>
+    );
+  }
+
+  if (storageType === 'localstorage') {
+    return (
+      <PageLayout activePath='/admin/live-stats'>
+        <div className='max-w-6xl mx-auto px-4 py-8'>
+          <div className='mb-8'>
+            <h1 className='text-3xl font-bold text-gray-900 dark:text-white'>
+              直播统计
+            </h1>
+            <p className='text-gray-600 dark:text-gray-400 mt-2'>
+              查看用户直播观看情况
+            </p>
+          </div>
+
+          <div className='p-6 bg-yellow-50 dark:bg-yellow-900/20 rounded-lg border border-yellow-200 dark:border-yellow-800'>
+            <div className='flex items-center space-x-3'>
+              <div className='text-yellow-600 dark:text-yellow-400'>
+                <svg
+                  className='w-6 h-6'
+                  fill='none'
+                  stroke='currentColor'
+                  viewBox='0 0 24 24'
+                >
+                  <path
+                    strokeLinecap='round'
+                    strokeLinejoin='round'
+                    strokeWidth='2'
+                    d='M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z'
+                  />
+                </svg>
+              </div>
+              <div>
+                <h3 className='text-lg font-semibold text-yellow-800 dark:text-yellow-300'>
+                  统计功能不可用
+                </h3>
+                <p className='text-yellow-700 dark:text-yellow-400 mt-1'>
+                  当前使用本地存储模式（localStorage），不支持统计功能。
+                  <br />
+                  如需使用此功能，请配置 Redis 或 Upstash 数据库存储。
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </PageLayout>
+    );
+  }
+
+  if (!statsData) {
+    return (
+      <PageLayout activePath='/admin/live-stats'>
+        <div className='max-w-6xl mx-auto px-4 py-8'>
+          <div className='text-center py-12'>
+            {error ? (
+              <div className='text-red-600 dark:text-red-400'>{error}</div>
+            ) : (
+              <div className='text-gray-600 dark:text-gray-400'>
+                加载直播统计中...
+              </div>
+            )}
+          </div>
+        </div>
+      </PageLayout>
+    );
+  }
+
+  // 计算每个用户观看的频道统计
+  const getUserChannelStats = (username: string) => {
+    const userStat = statsData.userStats.find((u) => u.username === username);
+    if (!userStat || !userStat.recentRecords) return [];
+
+    const channelMap: Record<
+      string,
+      { name: string; duration: number; count: number }
+    > = {};
+
+    userStat.recentRecords.forEach((record) => {
+      const key = record.channelName;
+      if (!channelMap[key]) {
+        channelMap[key] = { name: record.channelName, duration: 0, count: 0 };
+      }
+      channelMap[key].duration += record.duration;
+      channelMap[key].count += 1;
+    });
+
+    return Object.values(channelMap).sort((a, b) => b.duration - a.duration);
+  };
+
+  return (
+    <PageLayout activePath='/admin/live-stats'>
+      <div className='max-w-7xl mx-auto px-4 py-8'>
+        {/* 页面标题和刷新按钮 */}
+        <div className='flex justify-between items-start mb-8'>
+          <div>
+            <h1 className='text-3xl font-bold text-gray-900 dark:text-white'>
+              直播统计
+            </h1>
+            <p className='text-gray-600 dark:text-gray-400 mt-2'>
+              查看用户直播观看情况
+            </p>
+          </div>
+          <button
+            onClick={handleRefreshClick}
+            disabled={loading}
+            className='px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white text-sm rounded-lg transition-colors flex items-center space-x-2'
+          >
+            <svg
+              className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`}
+              fill='none'
+              stroke='currentColor'
+              viewBox='0 0 24 24'
+            >
+              <path
+                strokeLinecap='round'
+                strokeLinejoin='round'
+                strokeWidth='2'
+                d='M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15'
+              />
+            </svg>
+            <span>{loading ? '刷新中...' : '刷新数据'}</span>
+          </button>
+        </div>
+
+        {/* 错误提示 */}
+        {error && (
+          <div className='mb-8 p-4 bg-red-50 dark:bg-red-900/20 rounded-lg border border-red-200 dark:border-red-800'>
+            <div className='flex items-center space-x-3'>
+              <div className='text-red-600 dark:text-red-400'>
+                <svg
+                  className='w-5 h-5'
+                  fill='none'
+                  stroke='currentColor'
+                  viewBox='0 0 24 24'
+                >
+                  <path
+                    strokeLinecap='round'
+                    strokeLinejoin='round'
+                    strokeWidth='2'
+                    d='M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z'
+                  />
+                </svg>
+              </div>
+              <div>
+                <h4 className='text-sm font-medium text-red-800 dark:text-red-300'>
+                  获取统计数据失败
+                </h4>
+                <p className='text-red-700 dark:text-red-400 text-sm mt-1'>
+                  {error}
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* 全站统计概览 */}
+        <div className='grid grid-cols-1 md:grid-cols-3 gap-4 mb-8'>
+          <div className='p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800'>
+            <div className='text-2xl font-bold text-blue-800 dark:text-blue-300'>
+              {statsData.totalUsers}
+            </div>
+            <div className='text-sm text-blue-600 dark:text-blue-400'>
+              观看用户数
+            </div>
+          </div>
+          <div className='p-4 bg-green-50 dark:bg-green-900/20 rounded-lg border border-green-200 dark:border-green-800'>
+            <div className='text-2xl font-bold text-green-800 dark:text-green-300'>
+              {formatTime(statsData.totalWatchTime)}
+            </div>
+            <div className='text-sm text-green-600 dark:text-green-400'>
+              总观看时长
+            </div>
+          </div>
+          <div className='p-4 bg-purple-50 dark:bg-purple-900/20 rounded-lg border border-purple-200 dark:border-purple-800'>
+            <div className='text-2xl font-bold text-purple-800 dark:text-purple-300'>
+              {statsData.totalViews}
+            </div>
+            <div className='text-sm text-purple-600 dark:text-purple-400'>
+              总观看次数
+            </div>
+          </div>
+        </div>
+
+        {/* 用户直播观看统计 */}
+        <div>
+          <h3 className='text-xl font-semibold text-gray-900 dark:text-white mb-6'>
+            用户直播观看统计
+          </h3>
+          <div className='space-y-4'>
+            {statsData.userStats.map((userStat) => {
+              const channelStats = getUserChannelStats(userStat.username);
+
+              return (
+                <div
+                  key={userStat.username}
+                  className='border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden bg-white dark:bg-gray-800'
+                >
+                  {/* 用户概览行 */}
+                  <div
+                    className='p-4 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors'
+                    onClick={() => toggleUserExpanded(userStat.username)}
+                  >
+                    <div className='flex items-center justify-between'>
+                      <div className='flex items-center space-x-4'>
+                        <div className='flex-shrink-0'>
+                          <div className='w-10 h-10 bg-blue-100 dark:bg-blue-900 rounded-full flex items-center justify-center'>
+                            <span className='text-sm font-medium text-blue-600 dark:text-blue-400'>
+                              {userStat.username.charAt(0).toUpperCase()}
+                            </span>
+                          </div>
+                        </div>
+                        <div>
+                          <h5 className='text-sm font-medium text-gray-900 dark:text-gray-100'>
+                            {userStat.username}
+                          </h5>
+                          <p className='text-xs text-gray-500 dark:text-gray-400'>
+                            最后观看:{' '}
+                            {userStat.lastViewTime
+                              ? formatDateTime(userStat.lastViewTime)
+                              : '从未观看'}
+                          </p>
+                        </div>
+                      </div>
+                      <div className='flex items-center space-x-6'>
+                        <div className='text-right'>
+                          <div className='text-sm font-medium text-gray-900 dark:text-gray-100'>
+                            {formatTime(userStat.totalWatchTime)}
+                          </div>
+                          <div className='text-xs text-gray-500 dark:text-gray-400'>
+                            总观看时长
+                          </div>
+                        </div>
+                        <div className='text-right'>
+                          <div className='text-sm font-medium text-gray-900 dark:text-gray-100'>
+                            {userStat.totalViews}
+                          </div>
+                          <div className='text-xs text-gray-500 dark:text-gray-400'>
+                            观看次数
+                          </div>
+                        </div>
+                        <div className='flex-shrink-0'>
+                          <svg
+                            className={`w-5 h-5 text-gray-400 transition-transform ${
+                              expandedUsers.has(userStat.username)
+                                ? 'rotate-180'
+                                : ''
+                            }`}
+                            fill='none'
+                            stroke='currentColor'
+                            viewBox='0 0 24 24'
+                          >
+                            <path
+                              strokeLinecap='round'
+                              strokeLinejoin='round'
+                              strokeWidth='2'
+                              d='M19 9l-7 7-7-7'
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* 展开的频道详情 */}
+                  {expandedUsers.has(userStat.username) && (
+                    <div className='p-4 bg-gray-50 dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700'>
+                      {channelStats.length > 0 ? (
+                        <>
+                          <h6 className='text-sm font-medium text-gray-700 dark:text-gray-300 mb-4'>
+                            观看的频道列表
+                          </h6>
+                          <div className='space-y-3'>
+                            {channelStats.map((channel, index) => (
+                              <div
+                                key={`${channel.name}-${index}`}
+                                className='flex items-center justify-between p-3 bg-white dark:bg-gray-800 rounded-lg'
+                              >
+                                <div className='flex items-center space-x-3'>
+                                  <div className='w-8 h-8 bg-blue-100 dark:bg-blue-900 rounded-full flex items-center justify-center'>
+                                    <svg
+                                      className='w-4 h-4 text-blue-600 dark:text-blue-400'
+                                      fill='none'
+                                      stroke='currentColor'
+                                      viewBox='0 0 24 24'
+                                    >
+                                      <path
+                                        strokeLinecap='round'
+                                        strokeLinejoin='round'
+                                        strokeWidth='2'
+                                        d='M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z'
+                                      />
+                                    </svg>
+                                  </div>
+                                  <div>
+                                    <div className='text-sm font-medium text-gray-900 dark:text-gray-100'>
+                                      {channel.name}
+                                    </div>
+                                    <div className='text-xs text-gray-500 dark:text-gray-400'>
+                                      观看 {channel.count} 次
+                                    </div>
+                                  </div>
+                                </div>
+                                <div className='text-sm font-medium text-gray-900 dark:text-gray-100'>
+                                  {formatTime(channel.duration)}
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                        </>
+                      ) : (
+                        <div className='text-center py-8 text-gray-500 dark:text-gray-400'>
+                          <svg
+                            className='w-12 h-12 mx-auto mb-4 text-gray-300 dark:text-gray-600'
+                            fill='none'
+                            stroke='currentColor'
+                            viewBox='0 0 24 24'
+                          >
+                            <path
+                              strokeLinecap='round'
+                              strokeLinejoin='round'
+                              strokeWidth='2'
+                              d='M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z'
+                            />
+                          </svg>
+                          <p>该用户暂无直播观看记录</p>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* 返回顶部按钮 */}
+      <button
+        onClick={scrollToTop}
+        className={`fixed bottom-20 md:bottom-6 right-6 z-[500] w-12 h-12 bg-green-500/90 hover:bg-green-500 text-white rounded-full shadow-lg backdrop-blur-sm transition-all duration-300 ease-in-out flex items-center justify-center group ${
+          showBackToTop
+            ? 'opacity-100 translate-y-0 pointer-events-auto'
+            : 'opacity-0 translate-y-4 pointer-events-none'
+        }`}
+        aria-label='返回顶部'
+      >
+        <ChevronUp className='w-6 h-6 transition-transform group-hover:scale-110' />
+      </button>
+    </PageLayout>
+  );
+};
+
+export default LiveStatsPage;

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -52,45 +52,66 @@ import AIRecommendConfig from '@/components/AIRecommendConfig';
 import CacheManager from '@/components/CacheManager';
 import DataMigration from '@/components/DataMigration';
 import ImportExportModal from '@/components/ImportExportModal';
+import PageLayout from '@/components/PageLayout';
 import SourceTestModule from '@/components/SourceTestModule';
 import { TelegramAuthConfig } from '@/components/TelegramAuthConfig';
 import TVBoxSecurityConfig from '@/components/TVBoxSecurityConfig';
-import { TVBoxTokenCell, TVBoxTokenModal } from '@/components/TVBoxTokenManager';
+import {
+  TVBoxTokenCell,
+  TVBoxTokenModal,
+} from '@/components/TVBoxTokenManager';
 import YouTubeConfig from '@/components/YouTubeConfig';
-import PageLayout from '@/components/PageLayout';
 
 // 统一按钮样式系统
 const buttonStyles = {
   // 主要操作按钮（蓝色）- 用于配置、设置、确认等
-  primary: 'px-3 py-1.5 text-sm font-medium bg-blue-600 hover:bg-blue-700 dark:bg-blue-600 dark:hover:bg-blue-700 text-white rounded-lg transition-colors',
+  primary:
+    'px-3 py-1.5 text-sm font-medium bg-blue-600 hover:bg-blue-700 dark:bg-blue-600 dark:hover:bg-blue-700 text-white rounded-lg transition-colors',
   // 成功操作按钮（绿色）- 用于添加、启用、保存等
-  success: 'px-3 py-1.5 text-sm font-medium bg-green-600 hover:bg-green-700 dark:bg-green-600 dark:hover:bg-green-700 text-white rounded-lg transition-colors',
+  success:
+    'px-3 py-1.5 text-sm font-medium bg-green-600 hover:bg-green-700 dark:bg-green-600 dark:hover:bg-green-700 text-white rounded-lg transition-colors',
   // 危险操作按钮（红色）- 用于删除、禁用、重置等
-  danger: 'px-3 py-1.5 text-sm font-medium bg-red-600 hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-700 text-white rounded-lg transition-colors',
+  danger:
+    'px-3 py-1.5 text-sm font-medium bg-red-600 hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-700 text-white rounded-lg transition-colors',
   // 次要操作按钮（灰色）- 用于取消、关闭等
-  secondary: 'px-3 py-1.5 text-sm font-medium bg-gray-600 hover:bg-gray-700 dark:bg-gray-600 dark:hover:bg-gray-700 text-white rounded-lg transition-colors',
+  secondary:
+    'px-3 py-1.5 text-sm font-medium bg-gray-600 hover:bg-gray-700 dark:bg-gray-600 dark:hover:bg-gray-700 text-white rounded-lg transition-colors',
   // 警告操作按钮（黄色）- 用于批量禁用等
-  warning: 'px-3 py-1.5 text-sm font-medium bg-yellow-600 hover:bg-yellow-700 dark:bg-yellow-600 dark:hover:bg-yellow-700 text-white rounded-lg transition-colors',
+  warning:
+    'px-3 py-1.5 text-sm font-medium bg-yellow-600 hover:bg-yellow-700 dark:bg-yellow-600 dark:hover:bg-yellow-700 text-white rounded-lg transition-colors',
   // 小尺寸主要按钮
-  primarySmall: 'px-2 py-1 text-xs font-medium bg-blue-600 hover:bg-blue-700 dark:bg-blue-600 dark:hover:bg-blue-700 text-white rounded-md transition-colors',
+  primarySmall:
+    'px-2 py-1 text-xs font-medium bg-blue-600 hover:bg-blue-700 dark:bg-blue-600 dark:hover:bg-blue-700 text-white rounded-md transition-colors',
   // 小尺寸成功按钮
-  successSmall: 'px-2 py-1 text-xs font-medium bg-green-600 hover:bg-green-700 dark:bg-green-600 dark:hover:bg-green-700 text-white rounded-md transition-colors',
+  successSmall:
+    'px-2 py-1 text-xs font-medium bg-green-600 hover:bg-green-700 dark:bg-green-600 dark:hover:bg-green-700 text-white rounded-md transition-colors',
   // 小尺寸危险按钮
-  dangerSmall: 'px-2 py-1 text-xs font-medium bg-red-600 hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-700 text-white rounded-md transition-colors',
+  dangerSmall:
+    'px-2 py-1 text-xs font-medium bg-red-600 hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-700 text-white rounded-md transition-colors',
   // 小尺寸次要按钮
-  secondarySmall: 'px-2 py-1 text-xs font-medium bg-gray-600 hover:bg-gray-700 dark:bg-gray-600 dark:hover:bg-gray-700 text-white rounded-md transition-colors',
+  secondarySmall:
+    'px-2 py-1 text-xs font-medium bg-gray-600 hover:bg-gray-700 dark:bg-gray-600 dark:hover:bg-gray-700 text-white rounded-md transition-colors',
   // 小尺寸警告按钮
-  warningSmall: 'px-2 py-1 text-xs font-medium bg-yellow-600 hover:bg-yellow-700 dark:bg-yellow-600 dark:hover:bg-yellow-700 text-white rounded-md transition-colors',
+  warningSmall:
+    'px-2 py-1 text-xs font-medium bg-yellow-600 hover:bg-yellow-700 dark:bg-yellow-600 dark:hover:bg-yellow-700 text-white rounded-md transition-colors',
   // 圆角小按钮（用于表格操作）
-  roundedPrimary: 'inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900/40 dark:hover:bg-blue-900/60 dark:text-blue-200 transition-colors',
-  roundedSuccess: 'inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium bg-green-100 text-green-800 hover:bg-green-200 dark:bg-green-900/40 dark:hover:bg-green-900/60 dark:text-green-200 transition-colors',
-  roundedDanger: 'inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium bg-red-100 text-red-800 hover:bg-red-200 dark:bg-red-900/40 dark:hover:bg-red-900/60 dark:text-red-200 transition-colors',
-  roundedSecondary: 'inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800 hover:bg-gray-200 dark:bg-gray-700/40 dark:hover:bg-gray-700/60 dark:text-gray-200 transition-colors',
-  roundedWarning: 'inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800 hover:bg-yellow-200 dark:bg-yellow-900/40 dark:hover:bg-yellow-900/60 dark:text-yellow-200 transition-colors',
-  roundedPurple: 'inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800 hover:bg-purple-200 dark:bg-purple-900/40 dark:hover:bg-purple-900/60 dark:text-purple-200 transition-colors',
+  roundedPrimary:
+    'inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900/40 dark:hover:bg-blue-900/60 dark:text-blue-200 transition-colors',
+  roundedSuccess:
+    'inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium bg-green-100 text-green-800 hover:bg-green-200 dark:bg-green-900/40 dark:hover:bg-green-900/60 dark:text-green-200 transition-colors',
+  roundedDanger:
+    'inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium bg-red-100 text-red-800 hover:bg-red-200 dark:bg-red-900/40 dark:hover:bg-red-900/60 dark:text-red-200 transition-colors',
+  roundedSecondary:
+    'inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800 hover:bg-gray-200 dark:bg-gray-700/40 dark:hover:bg-gray-700/60 dark:text-gray-200 transition-colors',
+  roundedWarning:
+    'inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800 hover:bg-yellow-200 dark:bg-yellow-900/40 dark:hover:bg-yellow-900/60 dark:text-yellow-200 transition-colors',
+  roundedPurple:
+    'inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800 hover:bg-purple-200 dark:bg-purple-900/40 dark:hover:bg-purple-900/60 dark:text-purple-200 transition-colors',
   // 禁用状态
-  disabled: 'px-3 py-1.5 text-sm font-medium bg-gray-400 dark:bg-gray-600 cursor-not-allowed text-white rounded-lg transition-colors',
-  disabledSmall: 'px-2 py-1 text-xs font-medium bg-gray-400 dark:bg-gray-600 cursor-not-allowed text-white rounded-md transition-colors',
+  disabled:
+    'px-3 py-1.5 text-sm font-medium bg-gray-400 dark:bg-gray-600 cursor-not-allowed text-white rounded-lg transition-colors',
+  disabledSmall:
+    'px-2 py-1 text-xs font-medium bg-gray-400 dark:bg-gray-600 cursor-not-allowed text-white rounded-md transition-colors',
   // 开关按钮样式
   toggleOn: 'bg-green-600 dark:bg-green-600',
   toggleOff: 'bg-gray-200 dark:bg-gray-700',
@@ -98,7 +119,8 @@ const buttonStyles = {
   toggleThumbOn: 'translate-x-6',
   toggleThumbOff: 'translate-x-1',
   // 快速操作按钮样式
-  quickAction: 'px-3 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-400 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-md transition-colors',
+  quickAction:
+    'px-3 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-400 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-md transition-colors',
 };
 
 // 通用弹窗组件
@@ -119,7 +141,7 @@ const AlertModal = ({
   title,
   message,
   timer,
-  showConfirm = false
+  showConfirm = false,
 }: AlertModalProps) => {
   const [isVisible, setIsVisible] = useState(false);
 
@@ -141,11 +163,11 @@ const AlertModal = ({
   const getIcon = () => {
     switch (type) {
       case 'success':
-        return <CheckCircle className="w-8 h-8 text-green-500" />;
+        return <CheckCircle className='w-8 h-8 text-green-500' />;
       case 'error':
-        return <AlertCircle className="w-8 h-8 text-red-500" />;
+        return <AlertCircle className='w-8 h-8 text-red-500' />;
       case 'warning':
-        return <AlertTriangle className="w-8 h-8 text-yellow-500" />;
+        return <AlertTriangle className='w-8 h-8 text-yellow-500' />;
       default:
         return null;
     }
@@ -165,21 +187,25 @@ const AlertModal = ({
   };
 
   return createPortal(
-    <div className={`fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4 transition-opacity duration-200 ${isVisible ? 'opacity-100' : 'opacity-0'}`}>
-      <div className={`bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-sm w-full border ${getBgColor()} transition-all duration-200 ${isVisible ? 'scale-100' : 'scale-95'}`}>
-        <div className="p-6 text-center">
-          <div className="flex justify-center mb-4">
-            {getIcon()}
-          </div>
+    <div
+      className={`fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4 transition-opacity duration-200 ${
+        isVisible ? 'opacity-100' : 'opacity-0'
+      }`}
+    >
+      <div
+        className={`bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-sm w-full border ${getBgColor()} transition-all duration-200 ${
+          isVisible ? 'scale-100' : 'scale-95'
+        }`}
+      >
+        <div className='p-6 text-center'>
+          <div className='flex justify-center mb-4'>{getIcon()}</div>
 
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
+          <h3 className='text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2'>
             {title}
           </h3>
 
           {message && (
-            <p className="text-gray-600 dark:text-gray-400 mb-4">
-              {message}
-            </p>
+            <p className='text-gray-600 dark:text-gray-400 mb-4'>{message}</p>
           )}
 
           {showConfirm && (
@@ -217,7 +243,7 @@ const useAlertModal = () => {
   };
 
   const hideAlert = () => {
-    setAlertModal(prev => ({ ...prev, isOpen: false }));
+    setAlertModal((prev) => ({ ...prev, isOpen: false }));
   };
 
   return { alertModal, showAlert, hideAlert };
@@ -249,12 +275,15 @@ const useLoadingState = () => {
   const [loadingStates, setLoadingStates] = useState<LoadingState>({});
 
   const setLoading = (key: string, loading: boolean) => {
-    setLoadingStates(prev => ({ ...prev, [key]: loading }));
+    setLoadingStates((prev) => ({ ...prev, [key]: loading }));
   };
 
   const isLoading = (key: string) => loadingStates[key] || false;
 
-  const withLoading = async (key: string, operation: () => Promise<any>): Promise<any> => {
+  const withLoading = async (
+    key: string,
+    operation: () => Promise<any>
+  ): Promise<any> => {
     setLoading(key, true);
     try {
       const result = await operation();
@@ -398,8 +427,10 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
     showAdultContent?: boolean;
   } | null>(null);
   const [selectedApis, setSelectedApis] = useState<string[]>([]);
-  const [selectedShowAdultContent, setSelectedShowAdultContent] = useState<boolean>(false);
-  const [showConfigureUserGroupModal, setShowConfigureUserGroupModal] = useState(false);
+  const [selectedShowAdultContent, setSelectedShowAdultContent] =
+    useState<boolean>(false);
+  const [showConfigureUserGroupModal, setShowConfigureUserGroupModal] =
+    useState(false);
   const [selectedUserForGroup, setSelectedUserForGroup] = useState<{
     username: string;
     role: 'user' | 'admin' | 'owner';
@@ -409,10 +440,14 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
   const [selectedUsers, setSelectedUsers] = useState<Set<string>>(new Set());
   const [showBatchUserGroupModal, setShowBatchUserGroupModal] = useState(false);
   const [selectedUserGroup, setSelectedUserGroup] = useState<string>('');
-  const [showDeleteUserGroupModal, setShowDeleteUserGroupModal] = useState(false);
+  const [showDeleteUserGroupModal, setShowDeleteUserGroupModal] =
+    useState(false);
   const [deletingUserGroup, setDeletingUserGroup] = useState<{
     name: string;
-    affectedUsers: Array<{ username: string; role: 'user' | 'admin' | 'owner' }>;
+    affectedUsers: Array<{
+      username: string;
+      role: 'user' | 'admin' | 'owner';
+    }>;
   } | null>(null);
   const [showDeleteUserModal, setShowDeleteUserModal] = useState(false);
   const [deletingUser, setDeletingUser] = useState<string | null>(null);
@@ -424,19 +459,22 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
     tvboxToken?: string;
     tvboxEnabledSources?: string[];
   } | null>(null);
-  const [selectedTVBoxSources, setSelectedTVBoxSources] = useState<string[]>([]);
+  const [selectedTVBoxSources, setSelectedTVBoxSources] = useState<string[]>(
+    []
+  );
 
   // 当前登录用户名
   const currentUsername = getAuthInfoFromBrowserCookie()?.username || null;
 
   // 使用 useMemo 计算全选状态，避免每次渲染都重新计算
   const selectAllUsers = useMemo(() => {
-    const selectableUserCount = config?.UserConfig?.Users?.filter(user =>
-    (role === 'owner' ||
-      (role === 'admin' &&
-        (user.role === 'user' ||
-          user.username === currentUsername)))
-    ).length || 0;
+    const selectableUserCount =
+      config?.UserConfig?.Users?.filter(
+        (user) =>
+          role === 'owner' ||
+          (role === 'admin' &&
+            (user.role === 'user' || user.username === currentUsername))
+      ).length || 0;
     return selectedUsers.size === selectableUserCount && selectedUsers.size > 0;
   }, [selectedUsers.size, config?.UserConfig?.Users, role, currentUsername]);
 
@@ -472,14 +510,25 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
         await refreshConfig();
 
         if (action === 'add') {
-          setNewUserGroup({ name: '', enabledApis: [], showAdultContent: false });
+          setNewUserGroup({
+            name: '',
+            enabledApis: [],
+            showAdultContent: false,
+          });
           setShowAddUserGroupForm(false);
         } else if (action === 'edit') {
           setEditingUserGroup(null);
           setShowEditUserGroupForm(false);
         }
 
-        showSuccess(action === 'add' ? '用户组添加成功' : action === 'edit' ? '用户组更新成功' : '用户组删除成功', showAlert);
+        showSuccess(
+          action === 'add'
+            ? '用户组添加成功'
+            : action === 'edit'
+            ? '用户组更新成功'
+            : '用户组删除成功',
+          showAlert
+        );
       } catch (err) {
         showError(err instanceof Error ? err.message : '操作失败', showAlert);
         throw err;
@@ -489,23 +538,37 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
 
   const handleAddUserGroup = () => {
     if (!newUserGroup.name.trim()) return;
-    handleUserGroupAction('add', newUserGroup.name, newUserGroup.enabledApis, newUserGroup.showAdultContent);
+    handleUserGroupAction(
+      'add',
+      newUserGroup.name,
+      newUserGroup.enabledApis,
+      newUserGroup.showAdultContent
+    );
   };
 
   const handleEditUserGroup = () => {
     if (!editingUserGroup?.name.trim()) return;
-    handleUserGroupAction('edit', editingUserGroup.name, editingUserGroup.enabledApis, editingUserGroup.showAdultContent);
+    handleUserGroupAction(
+      'edit',
+      editingUserGroup.name,
+      editingUserGroup.enabledApis,
+      editingUserGroup.showAdultContent
+    );
   };
 
   const handleDeleteUserGroup = (groupName: string) => {
     // 计算会受影响的用户数量
-    const affectedUsers = config?.UserConfig?.Users?.filter(user =>
-      user.tags && user.tags.includes(groupName)
-    ) || [];
+    const affectedUsers =
+      config?.UserConfig?.Users?.filter(
+        (user) => user.tags && user.tags.includes(groupName)
+      ) || [];
 
     setDeletingUserGroup({
       name: groupName,
-      affectedUsers: affectedUsers.map(u => ({ username: u.username, role: u.role }))
+      affectedUsers: affectedUsers.map((u) => ({
+        username: u.username,
+        role: u.role,
+      })),
     });
     setShowDeleteUserGroupModal(true);
   };
@@ -522,14 +585,20 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
     }
   };
 
-  const handleStartEditUserGroup = (group: { name: string; enabledApis: string[] }) => {
+  const handleStartEditUserGroup = (group: {
+    name: string;
+    enabledApis: string[];
+  }) => {
     setEditingUserGroup({ ...group });
     setShowEditUserGroupForm(true);
     setShowAddUserGroupForm(false);
   };
 
   // 为用户分配用户组
-  const handleAssignUserGroup = async (username: string, userGroups: string[]) => {
+  const handleAssignUserGroup = async (
+    username: string,
+    userGroups: string[]
+  ) => {
     return withLoading(`assignUserGroup_${username}`, async () => {
       try {
         const res = await fetch('/api/admin/user', {
@@ -561,21 +630,32 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
   };
 
   const handleUnbanUser = async (uname: string) => {
-    await withLoading(`unbanUser_${uname}`, () => handleUserAction('unban', uname));
+    await withLoading(`unbanUser_${uname}`, () =>
+      handleUserAction('unban', uname)
+    );
   };
 
   const handleSetAdmin = async (uname: string) => {
-    await withLoading(`setAdmin_${uname}`, () => handleUserAction('setAdmin', uname));
+    await withLoading(`setAdmin_${uname}`, () =>
+      handleUserAction('setAdmin', uname)
+    );
   };
 
   const handleRemoveAdmin = async (uname: string) => {
-    await withLoading(`removeAdmin_${uname}`, () => handleUserAction('cancelAdmin', uname));
+    await withLoading(`removeAdmin_${uname}`, () =>
+      handleUserAction('cancelAdmin', uname)
+    );
   };
 
   const handleAddUser = async () => {
     if (!newUser.username || !newUser.password) return;
     await withLoading('addUser', async () => {
-      await handleUserAction('add', newUser.username, newUser.password, newUser.userGroup);
+      await handleUserAction(
+        'add',
+        newUser.username,
+        newUser.password,
+        newUser.userGroup
+      );
       setNewUser({ username: '', password: '', userGroup: '' });
       setShowAddUserForm(false);
     });
@@ -583,15 +663,18 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
 
   const handleChangePassword = async () => {
     if (!changePasswordUser.username || !changePasswordUser.password) return;
-    await withLoading(`changePassword_${changePasswordUser.username}`, async () => {
-      await handleUserAction(
-        'changePassword',
-        changePasswordUser.username,
-        changePasswordUser.password
-      );
-      setChangePasswordUser({ username: '', password: '' });
-      setShowChangePasswordForm(false);
-    });
+    await withLoading(
+      `changePassword_${changePasswordUser.username}`,
+      async () => {
+        await handleUserAction(
+          'changePassword',
+          changePasswordUser.username,
+          changePasswordUser.password
+        );
+        setChangePasswordUser({ username: '', password: '' });
+        setShowChangePasswordForm(false);
+      }
+    );
   };
 
   const handleShowChangePasswordForm = (username: string) => {
@@ -630,21 +713,27 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
   const handleSaveUserGroups = async () => {
     if (!selectedUserForGroup) return;
 
-    await withLoading(`saveUserGroups_${selectedUserForGroup.username}`, async () => {
-      try {
-        await handleAssignUserGroup(selectedUserForGroup.username, selectedUserGroups);
-        setShowConfigureUserGroupModal(false);
-        setSelectedUserForGroup(null);
-        setSelectedUserGroups([]);
-      } catch (err) {
-        // 错误处理已在 handleAssignUserGroup 中处理
+    await withLoading(
+      `saveUserGroups_${selectedUserForGroup.username}`,
+      async () => {
+        try {
+          await handleAssignUserGroup(
+            selectedUserForGroup.username,
+            selectedUserGroups
+          );
+          setShowConfigureUserGroupModal(false);
+          setSelectedUserForGroup(null);
+          setSelectedUserGroups([]);
+        } catch (err) {
+          // 错误处理已在 handleAssignUserGroup 中处理
+        }
       }
-    });
+    );
   };
 
   // 处理用户选择
   const handleSelectUser = useCallback((username: string, checked: boolean) => {
-    setSelectedUsers(prev => {
+    setSelectedUsers((prev) => {
       const newSelectedUsers = new Set(prev);
       if (checked) {
         newSelectedUsers.add(username);
@@ -655,20 +744,24 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
     });
   }, []);
 
-  const handleSelectAllUsers = useCallback((checked: boolean) => {
-    if (checked) {
-      // 只选择自己有权限操作的用户
-      const selectableUsernames = config?.UserConfig?.Users?.filter(user =>
-      (role === 'owner' ||
-        (role === 'admin' &&
-          (user.role === 'user' ||
-            user.username === currentUsername)))
-      ).map(u => u.username) || [];
-      setSelectedUsers(new Set(selectableUsernames));
-    } else {
-      setSelectedUsers(new Set());
-    }
-  }, [config?.UserConfig?.Users, role, currentUsername]);
+  const handleSelectAllUsers = useCallback(
+    (checked: boolean) => {
+      if (checked) {
+        // 只选择自己有权限操作的用户
+        const selectableUsernames =
+          config?.UserConfig?.Users?.filter(
+            (user) =>
+              role === 'owner' ||
+              (role === 'admin' &&
+                (user.role === 'user' || user.username === currentUsername))
+          ).map((u) => u.username) || [];
+        setSelectedUsers(new Set(selectableUsernames));
+      } else {
+        setSelectedUsers(new Set());
+      }
+    },
+    [config?.UserConfig?.Users, role, currentUsername]
+  );
 
   // 批量设置用户组
   const handleBatchSetUserGroup = async (userGroup: string) => {
@@ -695,7 +788,10 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
         setSelectedUsers(new Set());
         setShowBatchUserGroupModal(false);
         setSelectedUserGroup('');
-        showSuccess(`已为 ${userCount} 个用户设置用户组: ${userGroup}`, showAlert);
+        showSuccess(
+          `已为 ${userCount} 个用户设置用户组: ${userGroup}`,
+          showAlert
+        );
 
         // 刷新配置
         await refreshConfig();
@@ -705,8 +801,6 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
       }
     });
   };
-
-
 
   // 提取URL域名的辅助函数
   const extractDomain = (url: string): string => {
@@ -810,7 +904,9 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
       <div className='flex justify-center items-center py-8'>
         <div className='flex items-center gap-3 px-6 py-3 bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20 rounded-xl border border-blue-200/50 dark:border-blue-700/50 shadow-md'>
           <div className='animate-spin rounded-full h-5 w-5 border-2 border-blue-300 border-t-blue-600 dark:border-blue-700 dark:border-t-blue-400'></div>
-          <span className='text-sm font-medium text-gray-700 dark:text-gray-300'>加载配置中...</span>
+          <span className='text-sm font-medium text-gray-700 dark:text-gray-300'>
+            加载配置中...
+          </span>
         </div>
       </div>
     );
@@ -836,11 +932,13 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
               </div>
               <div className='flex items-center'>
                 <button
-                  type="button"
+                  type='button'
                   className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 ${
-                    config.UserConfig.AllowRegister ? buttonStyles.toggleOn : buttonStyles.toggleOff
+                    config.UserConfig.AllowRegister
+                      ? buttonStyles.toggleOn
+                      : buttonStyles.toggleOff
                   }`}
-                  role="switch"
+                  role='switch'
                   aria-checked={config.UserConfig.AllowRegister}
                   onClick={async () => {
                     await withLoading('toggleAllowRegister', async () => {
@@ -852,32 +950,41 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                             ...config,
                             UserConfig: {
                               ...config.UserConfig,
-                              AllowRegister: !config.UserConfig.AllowRegister
-                            }
-                          })
+                              AllowRegister: !config.UserConfig.AllowRegister,
+                            },
+                          }),
                         });
-                        
+
                         if (response.ok) {
                           await refreshConfig();
                           showAlert({
                             type: 'success',
                             title: '设置已更新',
-                            message: config.UserConfig.AllowRegister ? '已禁止用户注册' : '已允许用户注册',
-                            timer: 2000
+                            message: config.UserConfig.AllowRegister
+                              ? '已禁止用户注册'
+                              : '已允许用户注册',
+                            timer: 2000,
                           });
                         } else {
                           throw new Error('更新配置失败');
                         }
                       } catch (err) {
-                        showError(err instanceof Error ? err.message : '操作失败', showAlert);
+                        showError(
+                          err instanceof Error ? err.message : '操作失败',
+                          showAlert
+                        );
                       }
                     });
                   }}
                 >
                   <span
-                    aria-hidden="true"
-                    className={`pointer-events-none inline-block h-5 w-5 rounded-full ${buttonStyles.toggleThumb} shadow transform ring-0 transition duration-200 ease-in-out ${
-                      config.UserConfig.AllowRegister ? buttonStyles.toggleThumbOn : buttonStyles.toggleThumbOff
+                    aria-hidden='true'
+                    className={`pointer-events-none inline-block h-5 w-5 rounded-full ${
+                      buttonStyles.toggleThumb
+                    } shadow transform ring-0 transition duration-200 ease-in-out ${
+                      config.UserConfig.AllowRegister
+                        ? buttonStyles.toggleThumbOn
+                        : buttonStyles.toggleThumbOff
                     }`}
                   />
                 </button>
@@ -900,11 +1007,13 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                 </div>
                 <div className='flex items-center'>
                   <button
-                    type="button"
+                    type='button'
                     className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 ${
-                      config.UserConfig.AutoCleanupInactiveUsers ? buttonStyles.toggleOn : buttonStyles.toggleOff
+                      config.UserConfig.AutoCleanupInactiveUsers
+                        ? buttonStyles.toggleOn
+                        : buttonStyles.toggleOff
                     }`}
-                    role="switch"
+                    role='switch'
                     aria-checked={config.UserConfig.AutoCleanupInactiveUsers}
                     onClick={async () => {
                       await withLoading('toggleAutoCleanup', async () => {
@@ -916,9 +1025,10 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                               ...config,
                               UserConfig: {
                                 ...config.UserConfig,
-                                AutoCleanupInactiveUsers: !config.UserConfig.AutoCleanupInactiveUsers
-                              }
-                            })
+                                AutoCleanupInactiveUsers:
+                                  !config.UserConfig.AutoCleanupInactiveUsers,
+                              },
+                            }),
                           });
 
                           if (response.ok) {
@@ -926,8 +1036,11 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                             showAlert({
                               type: 'success',
                               title: '设置已更新',
-                              message: config.UserConfig.AutoCleanupInactiveUsers ? '已禁用自动清理' : '已启用自动清理',
-                              timer: 2000
+                              message: config.UserConfig
+                                .AutoCleanupInactiveUsers
+                                ? '已禁用自动清理'
+                                : '已启用自动清理',
+                              timer: 2000,
                             });
                           } else {
                             throw new Error('更新失败');
@@ -936,21 +1049,28 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                           showAlert({
                             type: 'error',
                             title: '更新失败',
-                            message: err instanceof Error ? err.message : '未知错误'
+                            message:
+                              err instanceof Error ? err.message : '未知错误',
                           });
                         }
                       });
                     }}
                   >
                     <span
-                      aria-hidden="true"
-                      className={`pointer-events-none inline-block h-5 w-5 rounded-full ${buttonStyles.toggleThumb} shadow transform ring-0 transition duration-200 ease-in-out ${
-                        config.UserConfig.AutoCleanupInactiveUsers ? buttonStyles.toggleThumbOn : buttonStyles.toggleThumbOff
+                      aria-hidden='true'
+                      className={`pointer-events-none inline-block h-5 w-5 rounded-full ${
+                        buttonStyles.toggleThumb
+                      } shadow transform ring-0 transition duration-200 ease-in-out ${
+                        config.UserConfig.AutoCleanupInactiveUsers
+                          ? buttonStyles.toggleThumbOn
+                          : buttonStyles.toggleThumbOff
                       }`}
                     />
                   </button>
                   <span className='ml-3 text-sm font-medium text-gray-900 dark:text-gray-100'>
-                    {config.UserConfig.AutoCleanupInactiveUsers ? '开启' : '关闭'}
+                    {config.UserConfig.AutoCleanupInactiveUsers
+                      ? '开启'
+                      : '关闭'}
                   </span>
                 </div>
               </div>
@@ -961,9 +1081,9 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                   保留天数：
                 </label>
                 <input
-                  type="number"
-                  min="1"
-                  max="365"
+                  type='number'
+                  min='1'
+                  max='365'
                   defaultValue={config.UserConfig.InactiveUserDays || 7}
                   onBlur={async (e) => {
                     const days = parseInt(e.target.value) || 7;
@@ -980,9 +1100,9 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                             ...config,
                             UserConfig: {
                               ...config.UserConfig,
-                              InactiveUserDays: days
-                            }
-                          })
+                              InactiveUserDays: days,
+                            },
+                          }),
                         });
 
                         if (response.ok) {
@@ -991,7 +1111,7 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                             type: 'success',
                             title: '设置已更新',
                             message: `保留天数已设置为${days}天`,
-                            timer: 2000
+                            timer: 2000,
                           });
                         } else {
                           throw new Error('更新失败');
@@ -1000,7 +1120,8 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                         showAlert({
                           type: 'error',
                           title: '更新失败',
-                          message: err instanceof Error ? err.message : '未知错误'
+                          message:
+                            err instanceof Error ? err.message : '未知错误',
                         });
                       }
                     });
@@ -1031,8 +1152,6 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
         </div>
       </div>
 
-
-
       {/* 用户组管理 */}
       <div>
         <div className='flex items-center justify-between mb-3'>
@@ -1047,7 +1166,11 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                 setEditingUserGroup(null);
               }
             }}
-            className={showAddUserGroupForm ? buttonStyles.secondary : buttonStyles.primary}
+            className={
+              showAddUserGroupForm
+                ? buttonStyles.secondary
+                : buttonStyles.primary
+            }
           >
             {showAddUserGroupForm ? '取消' : '添加用户组'}
           </button>
@@ -1071,7 +1194,10 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
             </thead>
             <tbody className='divide-y divide-gray-200 dark:divide-gray-700'>
               {userGroups.map((group) => (
-                <tr key={group.name} className='hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors'>
+                <tr
+                  key={group.name}
+                  className='hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors'
+                >
                   <td className='px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100'>
                     {group.name}
                   </td>
@@ -1088,7 +1214,11 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                     <button
                       onClick={() => handleStartEditUserGroup(group)}
                       disabled={isLoading(`userGroup_edit_${group.name}`)}
-                      className={`${buttonStyles.roundedPrimary} ${isLoading(`userGroup_edit_${group.name}`) ? 'opacity-50 cursor-not-allowed' : ''}`}
+                      className={`${buttonStyles.roundedPrimary} ${
+                        isLoading(`userGroup_edit_${group.name}`)
+                          ? 'opacity-50 cursor-not-allowed'
+                          : ''
+                      }`}
                     >
                       编辑
                     </button>
@@ -1107,14 +1237,28 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                     <div className='flex flex-col items-center justify-center'>
                       <div className='relative mb-4'>
                         <div className='w-16 h-16 bg-gradient-to-br from-blue-100 to-indigo-200 dark:from-blue-900/40 dark:to-indigo-900/40 rounded-2xl flex items-center justify-center shadow-lg'>
-                          <svg className='w-8 h-8 text-blue-500 dark:text-blue-400' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                            <path strokeLinecap='round' strokeLinejoin='round' strokeWidth='2' d='M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z'></path>
+                          <svg
+                            className='w-8 h-8 text-blue-500 dark:text-blue-400'
+                            fill='none'
+                            stroke='currentColor'
+                            viewBox='0 0 24 24'
+                          >
+                            <path
+                              strokeLinecap='round'
+                              strokeLinejoin='round'
+                              strokeWidth='2'
+                              d='M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z'
+                            ></path>
                           </svg>
                         </div>
                         <div className='absolute -top-1 -right-1 w-3 h-3 bg-blue-400 rounded-full animate-ping'></div>
                       </div>
-                      <p className='text-sm font-medium text-gray-700 dark:text-gray-300 mb-1'>暂无用户组</p>
-                      <p className='text-xs text-gray-500 dark:text-gray-400'>请添加用户组来管理用户权限</p>
+                      <p className='text-sm font-medium text-gray-700 dark:text-gray-300 mb-1'>
+                        暂无用户组
+                      </p>
+                      <p className='text-xs text-gray-500 dark:text-gray-400'>
+                        请添加用户组来管理用户权限
+                      </p>
                     </div>
                   </td>
                 </tr>
@@ -1156,7 +1300,9 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                   setChangePasswordUser({ username: '', password: '' });
                 }
               }}
-              className={showAddUserForm ? buttonStyles.secondary : buttonStyles.success}
+              className={
+                showAddUserForm ? buttonStyles.secondary : buttonStyles.success
+              }
             >
               {showAddUserForm ? '取消' : '添加用户'}
             </button>
@@ -1173,7 +1319,10 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                   placeholder='用户名'
                   value={newUser.username}
                   onChange={(e) =>
-                    setNewUser((prev) => ({ ...prev, username: e.target.value }))
+                    setNewUser((prev) => ({
+                      ...prev,
+                      username: e.target.value,
+                    }))
                   }
                   className='px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-green-500 focus:border-transparent'
                 />
@@ -1182,7 +1331,10 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                   placeholder='密码'
                   value={newUser.password}
                   onChange={(e) =>
-                    setNewUser((prev) => ({ ...prev, password: e.target.value }))
+                    setNewUser((prev) => ({
+                      ...prev,
+                      password: e.target.value,
+                    }))
                   }
                   className='px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-green-500 focus:border-transparent'
                 />
@@ -1194,14 +1346,21 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                 <select
                   value={newUser.userGroup}
                   onChange={(e) =>
-                    setNewUser((prev) => ({ ...prev, userGroup: e.target.value }))
+                    setNewUser((prev) => ({
+                      ...prev,
+                      userGroup: e.target.value,
+                    }))
                   }
                   className='w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-green-500 focus:border-transparent'
                 >
                   <option value=''>无用户组（无限制）</option>
                   {userGroups.map((group) => (
                     <option key={group.name} value={group.name}>
-                      {group.name} ({group.enabledApis && group.enabledApis.length > 0 ? `${group.enabledApis.length} 个源` : '无限制'})
+                      {group.name} (
+                      {group.enabledApis && group.enabledApis.length > 0
+                        ? `${group.enabledApis.length} 个源`
+                        : '无限制'}
+                      )
                     </option>
                   ))}
                 </select>
@@ -1209,8 +1368,18 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
               <div className='flex justify-end'>
                 <button
                   onClick={handleAddUser}
-                  disabled={!newUser.username || !newUser.password || isLoading('addUser')}
-                  className={!newUser.username || !newUser.password || isLoading('addUser') ? buttonStyles.disabled : buttonStyles.success}
+                  disabled={
+                    !newUser.username ||
+                    !newUser.password ||
+                    isLoading('addUser')
+                  }
+                  className={
+                    !newUser.username ||
+                    !newUser.password ||
+                    isLoading('addUser')
+                      ? buttonStyles.disabled
+                      : buttonStyles.success
+                  }
                 >
                   {isLoading('addUser') ? '添加中...' : '添加'}
                 </button>
@@ -1247,10 +1416,20 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
               />
               <button
                 onClick={handleChangePassword}
-                disabled={!changePasswordUser.password || isLoading(`changePassword_${changePasswordUser.username}`)}
-                className={`w-full sm:w-auto ${!changePasswordUser.password || isLoading(`changePassword_${changePasswordUser.username}`) ? buttonStyles.disabled : buttonStyles.primary}`}
+                disabled={
+                  !changePasswordUser.password ||
+                  isLoading(`changePassword_${changePasswordUser.username}`)
+                }
+                className={`w-full sm:w-auto ${
+                  !changePasswordUser.password ||
+                  isLoading(`changePassword_${changePasswordUser.username}`)
+                    ? buttonStyles.disabled
+                    : buttonStyles.primary
+                }`}
               >
-                {isLoading(`changePassword_${changePasswordUser.username}`) ? '修改中...' : '修改密码'}
+                {isLoading(`changePassword_${changePasswordUser.username}`)
+                  ? '修改中...'
+                  : '修改密码'}
               </button>
               <button
                 onClick={() => {
@@ -1266,7 +1445,10 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
         )}
 
         {/* 用户列表 */}
-        <div className='border border-gray-200 dark:border-gray-700 rounded-lg max-h-[28rem] overflow-y-auto overflow-x-auto relative' data-table="user-list">
+        <div
+          className='border border-gray-200 dark:border-gray-700 rounded-lg max-h-[28rem] overflow-y-auto overflow-x-auto relative'
+          data-table='user-list'
+        >
           <table className='min-w-full divide-y divide-gray-200 dark:divide-gray-700'>
             <thead className='bg-gray-50 dark:bg-gray-900 sticky top-0 z-10'>
               <tr>
@@ -1274,11 +1456,12 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                 <th className='w-10 px-1 py-3 text-center'>
                   {(() => {
                     // 检查是否有权限操作任何用户
-                    const hasAnyPermission = config?.UserConfig?.Users?.some(user =>
-                    (role === 'owner' ||
-                      (role === 'admin' &&
-                        (user.role === 'user' ||
-                          user.username === currentUsername)))
+                    const hasAnyPermission = config?.UserConfig?.Users?.some(
+                      (user) =>
+                        role === 'owner' ||
+                        (role === 'admin' &&
+                          (user.role === 'user' ||
+                            user.username === currentUsername))
                     );
 
                     return hasAnyPermission ? (
@@ -1378,14 +1561,19 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                       >
                         <td className='w-4' />
                         <td className='w-10 px-1 py-3 text-center'>
-                          {(role === 'owner' ||
-                            (role === 'admin' &&
-                              (user.role === 'user' ||
-                                user.username === currentUsername))) ? (
+                          {role === 'owner' ||
+                          (role === 'admin' &&
+                            (user.role === 'user' ||
+                              user.username === currentUsername)) ? (
                             <input
                               type='checkbox'
                               checked={selectedUsers.has(user.username)}
-                              onChange={(e) => handleSelectUser(user.username, e.target.checked)}
+                              onChange={(e) =>
+                                handleSelectUser(
+                                  user.username,
+                                  e.target.checked
+                                )
+                              }
                               className='w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
                             />
                           ) : (
@@ -1397,26 +1585,28 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                         </td>
                         <td className='px-6 py-4 whitespace-nowrap'>
                           <span
-                            className={`px-2 py-1 text-xs rounded-full ${user.role === 'owner'
-                              ? 'bg-yellow-100 dark:bg-yellow-900/20 text-yellow-800 dark:text-yellow-300'
-                              : user.role === 'admin'
+                            className={`px-2 py-1 text-xs rounded-full ${
+                              user.role === 'owner'
+                                ? 'bg-yellow-100 dark:bg-yellow-900/20 text-yellow-800 dark:text-yellow-300'
+                                : user.role === 'admin'
                                 ? 'bg-purple-100 dark:bg-purple-900/20 text-purple-800 dark:text-purple-300'
                                 : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'
-                              }`}
+                            }`}
                           >
                             {user.role === 'owner'
                               ? '站长'
                               : user.role === 'admin'
-                                ? '管理员'
-                                : '普通用户'}
+                              ? '管理员'
+                              : '普通用户'}
                           </span>
                         </td>
                         <td className='px-6 py-4 whitespace-nowrap'>
                           <span
-                            className={`px-2 py-1 text-xs rounded-full ${!user.banned
-                              ? 'bg-green-100 dark:bg-green-900/20 text-green-800 dark:text-green-300'
-                              : 'bg-red-100 dark:bg-red-900/20 text-red-800 dark:text-red-300'
-                              }`}
+                            className={`px-2 py-1 text-xs rounded-full ${
+                              !user.banned
+                                ? 'bg-green-100 dark:bg-green-900/20 text-green-800 dark:text-green-300'
+                                : 'bg-red-100 dark:bg-red-900/20 text-red-800 dark:text-red-300'
+                            }`}
                           >
                             {!user.banned ? '正常' : '已封禁'}
                           </span>
@@ -1433,13 +1623,13 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                               (role === 'admin' &&
                                 (user.role === 'user' ||
                                   user.username === currentUsername))) && (
-                                <button
-                                  onClick={() => handleConfigureUserGroup(user)}
-                                  className={buttonStyles.roundedPrimary}
-                                >
-                                  配置
-                                </button>
-                              )}
+                              <button
+                                onClick={() => handleConfigureUserGroup(user)}
+                                className={buttonStyles.roundedPrimary}
+                              >
+                                配置
+                              </button>
+                            )}
                           </div>
                         </td>
                         <td className='px-6 py-4 whitespace-nowrap'>
@@ -1454,13 +1644,13 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                               (role === 'admin' &&
                                 (user.role === 'user' ||
                                   user.username === currentUsername))) && (
-                                <button
-                                  onClick={() => handleConfigureUserApis(user)}
-                                  className={buttonStyles.roundedPrimary}
-                                >
-                                  配置
-                                </button>
-                              )}
+                              <button
+                                onClick={() => handleConfigureUserApis(user)}
+                                className={buttonStyles.roundedPrimary}
+                              >
+                                配置
+                              </button>
+                            )}
                           </div>
                         </td>
                         {/* TVBox Token 列 */}
@@ -1472,21 +1662,24 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                               (role === 'admin' &&
                                 (user.role === 'user' ||
                                   user.username === currentUsername))) && (
-                                <button
-                                  onClick={() => {
-                                    setTVBoxTokenUser({
-                                      username: user.username,
-                                      tvboxToken: user.tvboxToken,
-                                      tvboxEnabledSources: user.tvboxEnabledSources
-                                    });
-                                    setSelectedTVBoxSources(user.tvboxEnabledSources || []);
-                                    setShowTVBoxTokenModal(true);
-                                  }}
-                                  className={buttonStyles.roundedPrimary}
-                                >
-                                  配置
-                                </button>
-                              )}
+                              <button
+                                onClick={() => {
+                                  setTVBoxTokenUser({
+                                    username: user.username,
+                                    tvboxToken: user.tvboxToken,
+                                    tvboxEnabledSources:
+                                      user.tvboxEnabledSources,
+                                  });
+                                  setSelectedTVBoxSources(
+                                    user.tvboxEnabledSources || []
+                                  );
+                                  setShowTVBoxTokenModal(true);
+                                }}
+                                className={buttonStyles.roundedPrimary}
+                              >
+                                配置
+                              </button>
+                            )}
                           </div>
                         </td>
                         <td className='px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2'>
@@ -1507,8 +1700,14 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                               {user.role === 'user' && (
                                 <button
                                   onClick={() => handleSetAdmin(user.username)}
-                                  disabled={isLoading(`setAdmin_${user.username}`)}
-                                  className={`${buttonStyles.roundedPurple} ${isLoading(`setAdmin_${user.username}`) ? 'opacity-50 cursor-not-allowed' : ''}`}
+                                  disabled={isLoading(
+                                    `setAdmin_${user.username}`
+                                  )}
+                                  className={`${buttonStyles.roundedPurple} ${
+                                    isLoading(`setAdmin_${user.username}`)
+                                      ? 'opacity-50 cursor-not-allowed'
+                                      : ''
+                                  }`}
                                 >
                                   设为管理
                                 </button>
@@ -1518,8 +1717,16 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                                   onClick={() =>
                                     handleRemoveAdmin(user.username)
                                   }
-                                  disabled={isLoading(`removeAdmin_${user.username}`)}
-                                  className={`${buttonStyles.roundedSecondary} ${isLoading(`removeAdmin_${user.username}`) ? 'opacity-50 cursor-not-allowed' : ''}`}
+                                  disabled={isLoading(
+                                    `removeAdmin_${user.username}`
+                                  )}
+                                  className={`${
+                                    buttonStyles.roundedSecondary
+                                  } ${
+                                    isLoading(`removeAdmin_${user.username}`)
+                                      ? 'opacity-50 cursor-not-allowed'
+                                      : ''
+                                  }`}
                                 >
                                   取消管理
                                 </button>
@@ -1528,8 +1735,14 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                                 (!user.banned ? (
                                   <button
                                     onClick={() => handleBanUser(user.username)}
-                                    disabled={isLoading(`banUser_${user.username}`)}
-                                    className={`${buttonStyles.roundedDanger} ${isLoading(`banUser_${user.username}`) ? 'opacity-50 cursor-not-allowed' : ''}`}
+                                    disabled={isLoading(
+                                      `banUser_${user.username}`
+                                    )}
+                                    className={`${buttonStyles.roundedDanger} ${
+                                      isLoading(`banUser_${user.username}`)
+                                        ? 'opacity-50 cursor-not-allowed'
+                                        : ''
+                                    }`}
                                   >
                                     封禁
                                   </button>
@@ -1538,8 +1751,16 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                                     onClick={() =>
                                       handleUnbanUser(user.username)
                                     }
-                                    disabled={isLoading(`unbanUser_${user.username}`)}
-                                    className={`${buttonStyles.roundedSuccess} ${isLoading(`unbanUser_${user.username}`) ? 'opacity-50 cursor-not-allowed' : ''}`}
+                                    disabled={isLoading(
+                                      `unbanUser_${user.username}`
+                                    )}
+                                    className={`${
+                                      buttonStyles.roundedSuccess
+                                    } ${
+                                      isLoading(`unbanUser_${user.username}`)
+                                        ? 'opacity-50 cursor-not-allowed'
+                                        : ''
+                                    }`}
                                   >
                                     解封
                                   </button>
@@ -1567,228 +1788,99 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
       </div>
 
       {/* 配置用户采集源权限弹窗 */}
-      {showConfigureApisModal && selectedUser && createPortal(
-        <div className='fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4' onClick={() => {
-          setShowConfigureApisModal(false);
-          setSelectedUser(null);
-          setSelectedApis([]);
-          setSelectedShowAdultContent(false);
-        }}>
-          <div className='bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-4xl w-full max-h-[80vh] overflow-y-auto' onClick={(e) => e.stopPropagation()}>
-            <div className='p-6'>
-              <div className='flex items-center justify-between mb-6'>
-                <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
-                  配置用户采集源权限 - {selectedUser.username}
-                </h3>
-                <button
-                  onClick={() => {
-                    setShowConfigureApisModal(false);
-                    setSelectedUser(null);
-                    setSelectedApis([]);
-                    setSelectedShowAdultContent(false);
-                  }}
-                  className='text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors'
-                >
-                  <svg className='w-6 h-6' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                    <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M6 18L18 6M6 6l12 12' />
-                  </svg>
-                </button>
-              </div>
-
-              <div className='mb-6'>
-                <div className='bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4'>
-                  <div className='flex items-center space-x-2 mb-2'>
-                    <svg className='w-5 h-5 text-blue-600 dark:text-blue-400' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                      <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z' />
-                    </svg>
-                    <span className='text-sm font-medium text-blue-800 dark:text-blue-300'>
-                      配置说明
-                    </span>
-                  </div>
-                  <p className='text-sm text-blue-700 dark:text-blue-400 mt-1'>
-                    提示：全不选为无限制，选中的采集源将限制用户只能访问这些源
-                  </p>
-                </div>
-              </div>
-
-              {/* 采集源选择 - 多列布局 */}
-              <div className='mb-6'>
-                <h4 className='text-sm font-medium text-gray-700 dark:text-gray-300 mb-4'>
-                  选择可用的采集源：
-                </h4>
-                <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4'>
-                  {config?.SourceConfig?.map((source) => (
-                    <label key={source.key} className='flex items-center space-x-3 p-3 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer transition-colors'>
-                      <input
-                        type='checkbox'
-                        checked={selectedApis.includes(source.key)}
-                        onChange={(e) => {
-                          if (e.target.checked) {
-                            setSelectedApis([...selectedApis, source.key]);
-                          } else {
-                            setSelectedApis(selectedApis.filter(api => api !== source.key));
-                          }
-                        }}
-                        className='rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700'
-                      />
-                      <div className='flex-1 min-w-0'>
-                        <div className='text-sm font-medium text-gray-900 dark:text-gray-100 truncate'>
-                          {source.name}
-                        </div>
-                        {source.api && (
-                          <div className='text-xs text-gray-500 dark:text-gray-400 truncate'>
-                            {extractDomain(source.api)}
-                          </div>
-                        )}
-                      </div>
-                    </label>
-                  ))}
-                </div>
-              </div>
-
-              {/* 快速操作按钮 */}
-              <div className='flex flex-wrap items-center justify-between mb-6 p-4 bg-gray-50 dark:bg-gray-900 rounded-lg'>
-                <div className='flex space-x-2'>
-                  <button
-                    onClick={() => setSelectedApis([])}
-                    className={buttonStyles.quickAction}
-                  >
-                    全不选（无限制）
-                  </button>
+      {showConfigureApisModal &&
+        selectedUser &&
+        createPortal(
+          <div
+            className='fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4'
+            onClick={() => {
+              setShowConfigureApisModal(false);
+              setSelectedUser(null);
+              setSelectedApis([]);
+              setSelectedShowAdultContent(false);
+            }}
+          >
+            <div
+              className='bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-4xl w-full max-h-[80vh] overflow-y-auto'
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className='p-6'>
+                <div className='flex items-center justify-between mb-6'>
+                  <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
+                    配置用户采集源权限 - {selectedUser.username}
+                  </h3>
                   <button
                     onClick={() => {
-                      const allApis = config?.SourceConfig?.filter(source => !source.disabled).map(s => s.key) || [];
-                      setSelectedApis(allApis);
+                      setShowConfigureApisModal(false);
+                      setSelectedUser(null);
+                      setSelectedApis([]);
+                      setSelectedShowAdultContent(false);
                     }}
-                    className={buttonStyles.quickAction}
+                    className='text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors'
                   >
-                    全选
+                    <svg
+                      className='w-6 h-6'
+                      fill='none'
+                      stroke='currentColor'
+                      viewBox='0 0 24 24'
+                    >
+                      <path
+                        strokeLinecap='round'
+                        strokeLinejoin='round'
+                        strokeWidth={2}
+                        d='M6 18L18 6M6 6l12 12'
+                      />
+                    </svg>
                   </button>
                 </div>
-                <div className='text-sm text-gray-600 dark:text-gray-400'>
-                  已选择：<span className='font-medium text-blue-600 dark:text-blue-400'>
-                    {selectedApis.length > 0 ? `${selectedApis.length} 个源` : '无限制'}
-                  </span>
-                </div>
-              </div>
 
-              {/* 成人内容控制 */}
-              <div className='mb-6 p-4 bg-gradient-to-r from-red-50 to-pink-50 dark:from-red-900/20 dark:to-pink-900/20 rounded-lg border border-red-200 dark:border-red-800'>
-                <label className='flex items-center justify-between cursor-pointer'>
-                  <div className='flex-1'>
-                    <div className='flex items-center space-x-2'>
-                      <span className='text-base font-medium text-gray-900 dark:text-gray-100'>
-                        显示成人内容
+                <div className='mb-6'>
+                  <div className='bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4'>
+                    <div className='flex items-center space-x-2 mb-2'>
+                      <svg
+                        className='w-5 h-5 text-blue-600 dark:text-blue-400'
+                        fill='none'
+                        stroke='currentColor'
+                        viewBox='0 0 24 24'
+                      >
+                        <path
+                          strokeLinecap='round'
+                          strokeLinejoin='round'
+                          strokeWidth={2}
+                          d='M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z'
+                        />
+                      </svg>
+                      <span className='text-sm font-medium text-blue-800 dark:text-blue-300'>
+                        配置说明
                       </span>
-                      <span className='text-lg'>🔞</span>
                     </div>
-                    <p className='text-sm text-gray-600 dark:text-gray-400 mt-1'>
-                      允许此用户查看被标记为成人资源的视频源（需要同时启用站点级别和用户组级别的成人内容开关，优先级：用户 &gt; 用户组 &gt; 全局）
+                    <p className='text-sm text-blue-700 dark:text-blue-400 mt-1'>
+                      提示：全不选为无限制，选中的采集源将限制用户只能访问这些源
                     </p>
                   </div>
-                  <div className='relative inline-block ml-4'>
-                    <input
-                      type='checkbox'
-                      checked={selectedShowAdultContent}
-                      onChange={(e) => setSelectedShowAdultContent(e.target.checked)}
-                      className='sr-only peer'
-                    />
-                    <div className='w-14 h-7 bg-gray-300 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-red-300 dark:peer-focus:ring-red-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[""] after:absolute after:top-0.5 after:start-[4px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-6 after:w-6 after:transition-all dark:border-gray-600 peer-checked:bg-gradient-to-r peer-checked:from-red-600 peer-checked:to-pink-600'></div>
-                  </div>
-                </label>
-              </div>
-
-              {/* 操作按钮 */}
-              <div className='flex justify-end space-x-3'>
-                <button
-                  onClick={() => {
-                    setShowConfigureApisModal(false);
-                    setSelectedUser(null);
-                    setSelectedApis([]);
-                    setSelectedShowAdultContent(false);
-                  }}
-                  className={`px-6 py-2.5 text-sm font-medium ${buttonStyles.secondary}`}
-                >
-                  取消
-                </button>
-                <button
-                  onClick={handleSaveUserApis}
-                  disabled={isLoading(`saveUserApis_${selectedUser?.username}`)}
-                  className={`px-6 py-2.5 text-sm font-medium ${isLoading(`saveUserApis_${selectedUser?.username}`) ? buttonStyles.disabled : buttonStyles.primary}`}
-                >
-                  {isLoading(`saveUserApis_${selectedUser?.username}`) ? '配置中...' : '确认配置'}
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>,
-        document.body
-      )}
-
-      {/* 添加用户组弹窗 */}
-      {showAddUserGroupForm && createPortal(
-        <div className='fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4' onClick={() => {
-          setShowAddUserGroupForm(false);
-          setNewUserGroup({ name: '', enabledApis: [], showAdultContent: false });
-        }}>
-          <div className='bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-4xl w-full max-h-[80vh] overflow-y-auto' onClick={(e) => e.stopPropagation()}>
-            <div className='p-6'>
-              <div className='flex items-center justify-between mb-6'>
-                <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
-                  添加新用户组
-                </h3>
-                <button
-                  onClick={() => {
-                    setShowAddUserGroupForm(false);
-                    setNewUserGroup({ name: '', enabledApis: [], showAdultContent: false });
-                  }}
-                  className='text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors'
-                >
-                  <svg className='w-6 h-6' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                    <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M6 18L18 6M6 6l12 12' />
-                  </svg>
-                </button>
-              </div>
-
-              <div className='space-y-6'>
-                {/* 用户组名称 */}
-                <div>
-                  <label className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'>
-                    用户组名称
-                  </label>
-                  <input
-                    type='text'
-                    placeholder='请输入用户组名称'
-                    value={newUserGroup.name}
-                    onChange={(e) =>
-                      setNewUserGroup((prev) => ({ ...prev, name: e.target.value }))
-                    }
-                    className='w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent'
-                  />
                 </div>
 
-                {/* 可用视频源 */}
-                <div>
-                  <label className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-4'>
-                    可用视频源
-                  </label>
-                  <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3'>
+                {/* 采集源选择 - 多列布局 */}
+                <div className='mb-6'>
+                  <h4 className='text-sm font-medium text-gray-700 dark:text-gray-300 mb-4'>
+                    选择可用的采集源：
+                  </h4>
+                  <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4'>
                     {config?.SourceConfig?.map((source) => (
-                      <label key={source.key} className='flex items-center space-x-3 p-3 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer transition-colors'>
+                      <label
+                        key={source.key}
+                        className='flex items-center space-x-3 p-3 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer transition-colors'
+                      >
                         <input
                           type='checkbox'
-                          checked={newUserGroup.enabledApis.includes(source.key)}
+                          checked={selectedApis.includes(source.key)}
                           onChange={(e) => {
                             if (e.target.checked) {
-                              setNewUserGroup(prev => ({
-                                ...prev,
-                                enabledApis: [...prev.enabledApis, source.key]
-                              }));
+                              setSelectedApis([...selectedApis, source.key]);
                             } else {
-                              setNewUserGroup(prev => ({
-                                ...prev,
-                                enabledApis: prev.enabledApis.filter(api => api !== source.key)
-                              }));
+                              setSelectedApis(
+                                selectedApis.filter((api) => api !== source.key)
+                              );
                             }
                           }}
                           className='rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700'
@@ -1806,98 +1898,42 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                       </label>
                     ))}
                   </div>
+                </div>
 
-                  {/* 特殊功能权限 */}
-                  <div className="mt-6 pt-6 border-t border-gray-200 dark:border-gray-700">
-                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
-                      特殊功能权限
-                    </label>
-                    <div className="space-y-3">
-                      {/* AI推荐功能 */}
-                      <label className="flex items-center space-x-3 p-3 border border-orange-200 dark:border-orange-700 rounded-lg bg-orange-50 dark:bg-orange-900/10 hover:bg-orange-100 dark:hover:bg-orange-900/20 cursor-pointer transition-colors">
-                        <input
-                          type="checkbox"
-                          checked={newUserGroup.enabledApis.includes('ai-recommend')}
-                          onChange={(e) => {
-                            if (e.target.checked) {
-                              setNewUserGroup(prev => ({
-                                ...prev,
-                                enabledApis: [...prev.enabledApis, 'ai-recommend']
-                              }));
-                            } else {
-                              setNewUserGroup(prev => ({
-                                ...prev,
-                                enabledApis: prev.enabledApis.filter(api => api !== 'ai-recommend')
-                              }));
-                            }
-                          }}
-                          className="rounded border-orange-300 text-orange-600 focus:ring-orange-500 dark:border-orange-600 dark:bg-orange-700"
-                        />
-                        <div className="flex-1">
-                          <div className="text-sm font-medium text-orange-900 dark:text-orange-100">
-                            🤖 AI推荐功能
-                          </div>
-                          <div className="text-xs text-orange-700 dark:text-orange-300">
-                            智能推荐影视内容 (消耗OpenAI API费用)
-                          </div>
-                        </div>
-                      </label>
-
-                      {/* YouTube搜索功能 */}
-                      <label className="flex items-center space-x-3 p-3 border border-red-200 dark:border-red-700 rounded-lg bg-red-50 dark:bg-red-900/10 hover:bg-red-100 dark:hover:bg-red-900/20 cursor-pointer transition-colors">
-                        <input
-                          type="checkbox"
-                          checked={newUserGroup.enabledApis.includes('youtube-search')}
-                          onChange={(e) => {
-                            if (e.target.checked) {
-                              setNewUserGroup(prev => ({
-                                ...prev,
-                                enabledApis: [...prev.enabledApis, 'youtube-search']
-                              }));
-                            } else {
-                              setNewUserGroup(prev => ({
-                                ...prev,
-                                enabledApis: prev.enabledApis.filter(api => api !== 'youtube-search')
-                              }));
-                            }
-                          }}
-                          className="rounded border-red-300 text-red-600 focus:ring-red-500 dark:border-red-600 dark:bg-red-700"
-                        />
-                        <div className="flex-1">
-                          <div className="text-sm font-medium text-red-900 dark:text-red-100">
-                            📺 YouTube搜索功能
-                          </div>
-                          <div className="text-xs text-red-700 dark:text-red-300">
-                            搜索和推荐YouTube视频 (消耗YouTube API配额)
-                          </div>
-                        </div>
-                      </label>
-                    </div>
-                  </div>
-
-                  {/* 快速操作按钮 */}
-                  <div className='mt-4 flex space-x-2'>
+                {/* 快速操作按钮 */}
+                <div className='flex flex-wrap items-center justify-between mb-6 p-4 bg-gray-50 dark:bg-gray-900 rounded-lg'>
+                  <div className='flex space-x-2'>
                     <button
-                      onClick={() => setNewUserGroup(prev => ({ ...prev, enabledApis: [] }))}
+                      onClick={() => setSelectedApis([])}
                       className={buttonStyles.quickAction}
                     >
                       全不选（无限制）
                     </button>
                     <button
                       onClick={() => {
-                        const allApis = config?.SourceConfig?.filter(source => !source.disabled).map(s => s.key) || [];
-                        const specialFeatures = ['ai-recommend', 'youtube-search'];
-                        setNewUserGroup(prev => ({ ...prev, enabledApis: [...allApis, ...specialFeatures] }));
+                        const allApis =
+                          config?.SourceConfig?.filter(
+                            (source) => !source.disabled
+                          ).map((s) => s.key) || [];
+                        setSelectedApis(allApis);
                       }}
                       className={buttonStyles.quickAction}
                     >
                       全选
                     </button>
                   </div>
+                  <div className='text-sm text-gray-600 dark:text-gray-400'>
+                    已选择：
+                    <span className='font-medium text-blue-600 dark:text-blue-400'>
+                      {selectedApis.length > 0
+                        ? `${selectedApis.length} 个源`
+                        : '无限制'}
+                    </span>
+                  </div>
                 </div>
 
                 {/* 成人内容控制 */}
-                <div className='p-4 bg-gradient-to-r from-red-50 to-pink-50 dark:from-red-900/20 dark:to-pink-900/20 rounded-lg border border-red-200 dark:border-red-800'>
+                <div className='mb-6 p-4 bg-gradient-to-r from-red-50 to-pink-50 dark:from-red-900/20 dark:to-pink-900/20 rounded-lg border border-red-200 dark:border-red-800'>
                   <label className='flex items-center justify-between cursor-pointer'>
                     <div className='flex-1'>
                       <div className='flex items-center space-x-2'>
@@ -1907,595 +1943,767 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                         <span className='text-lg'>🔞</span>
                       </div>
                       <p className='text-sm text-gray-600 dark:text-gray-400 mt-1'>
-                        允许此用户组查看被标记为成人资源的视频源（需要同时启用站点级别的成人内容开关）
+                        允许此用户查看被标记为成人资源的视频源（需要同时启用站点级别和用户组级别的成人内容开关，优先级：用户
+                        &gt; 用户组 &gt; 全局）
                       </p>
                     </div>
                     <div className='relative inline-block ml-4'>
                       <input
                         type='checkbox'
-                        checked={newUserGroup.showAdultContent}
+                        checked={selectedShowAdultContent}
                         onChange={(e) =>
-                          setNewUserGroup((prev) => ({
-                            ...prev,
-                            showAdultContent: e.target.checked,
-                          }))
+                          setSelectedShowAdultContent(e.target.checked)
                         }
                         className='sr-only peer'
                       />
                       <div className='w-14 h-7 bg-gray-300 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-red-300 dark:peer-focus:ring-red-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[""] after:absolute after:top-0.5 after:start-[4px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-6 after:w-6 after:transition-all dark:border-gray-600 peer-checked:bg-gradient-to-r peer-checked:from-red-600 peer-checked:to-pink-600'></div>
                     </div>
                   </label>
-                </div>
-
-                {/* 操作按钮 */}
-                <div className='flex justify-end space-x-3 pt-4 border-t border-gray-200 dark:border-gray-700'>
-                  <button
-                    onClick={() => {
-                      setShowAddUserGroupForm(false);
-                      setNewUserGroup({ name: '', enabledApis: [], showAdultContent: false });
-                    }}
-                    className={`px-6 py-2.5 text-sm font-medium ${buttonStyles.secondary}`}
-                  >
-                    取消
-                  </button>
-                  <button
-                    onClick={handleAddUserGroup}
-                    disabled={!newUserGroup.name.trim() || isLoading('userGroup_add_new')}
-                    className={`px-6 py-2.5 text-sm font-medium ${!newUserGroup.name.trim() || isLoading('userGroup_add_new') ? buttonStyles.disabled : buttonStyles.primary}`}
-                  >
-                    {isLoading('userGroup_add_new') ? '添加中...' : '添加用户组'}
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>,
-        document.body
-      )}
-
-      {/* 编辑用户组弹窗 */}
-      {showEditUserGroupForm && editingUserGroup && createPortal(
-        <div className='fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4' onClick={() => {
-          setShowEditUserGroupForm(false);
-          setEditingUserGroup(null);
-        }}>
-          <div className='bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-4xl w-full max-h-[80vh] overflow-y-auto' onClick={(e) => e.stopPropagation()}>
-            <div className='p-6'>
-              <div className='flex items-center justify-between mb-6'>
-                <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
-                  编辑用户组 - {editingUserGroup.name}
-                </h3>
-                <button
-                  onClick={() => {
-                    setShowEditUserGroupForm(false);
-                    setEditingUserGroup(null);
-                  }}
-                  className='text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors'
-                >
-                  <svg className='w-6 h-6' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                    <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M6 18L18 6M6 6l12 12' />
-                  </svg>
-                </button>
-              </div>
-
-              <div className='space-y-6'>
-                {/* 可用视频源 */}
-                <div>
-                  <label className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-4'>
-                    可用视频源
-                  </label>
-                  <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3'>
-                    {config?.SourceConfig?.map((source) => (
-                      <label key={source.key} className='flex items-center space-x-3 p-3 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer transition-colors'>
-                        <input
-                          type='checkbox'
-                          checked={editingUserGroup.enabledApis.includes(source.key)}
-                          onChange={(e) => {
-                            if (e.target.checked) {
-                              setEditingUserGroup(prev => prev ? {
-                                ...prev,
-                                enabledApis: [...prev.enabledApis, source.key]
-                              } : null);
-                            } else {
-                              setEditingUserGroup(prev => prev ? {
-                                ...prev,
-                                enabledApis: prev.enabledApis.filter(api => api !== source.key)
-                              } : null);
-                            }
-                          }}
-                          className='rounded border-gray-300 text-purple-600 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-700'
-                        />
-                        <div className='flex-1 min-w-0'>
-                          <div className='text-sm font-medium text-gray-900 dark:text-gray-100 truncate'>
-                            {source.name}
-                          </div>
-                          {source.api && (
-                            <div className='text-xs text-gray-500 dark:text-gray-400 truncate'>
-                              {extractDomain(source.api)}
-                            </div>
-                          )}
-                        </div>
-                      </label>
-                    ))}
-                  </div>
-
-                  {/* 特殊功能权限 */}
-                  <div className="mt-6 pt-6 border-t border-gray-200 dark:border-gray-700">
-                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
-                      特殊功能权限
-                    </label>
-                    <div className="space-y-3">
-                      {/* AI推荐功能 */}
-                      <label className="flex items-center space-x-3 p-3 border border-orange-200 dark:border-orange-700 rounded-lg bg-orange-50 dark:bg-orange-900/10 hover:bg-orange-100 dark:hover:bg-orange-900/20 cursor-pointer transition-colors">
-                        <input
-                          type="checkbox"
-                          checked={editingUserGroup.enabledApis.includes('ai-recommend')}
-                          onChange={(e) => {
-                            if (e.target.checked) {
-                              setEditingUserGroup(prev => prev ? {
-                                ...prev,
-                                enabledApis: [...prev.enabledApis, 'ai-recommend']
-                              } : null);
-                            } else {
-                              setEditingUserGroup(prev => prev ? {
-                                ...prev,
-                                enabledApis: prev.enabledApis.filter(api => api !== 'ai-recommend')
-                              } : null);
-                            }
-                          }}
-                          className="rounded border-orange-300 text-orange-600 focus:ring-orange-500 dark:border-orange-600 dark:bg-orange-700"
-                        />
-                        <div className="flex-1">
-                          <div className="text-sm font-medium text-orange-900 dark:text-orange-100">
-                            🤖 AI推荐功能
-                          </div>
-                          <div className="text-xs text-orange-700 dark:text-orange-300">
-                            智能推荐影视内容 (消耗OpenAI API费用)
-                          </div>
-                        </div>
-                      </label>
-
-                      {/* YouTube搜索功能 */}
-                      <label className="flex items-center space-x-3 p-3 border border-red-200 dark:border-red-700 rounded-lg bg-red-50 dark:bg-red-900/10 hover:bg-red-100 dark:hover:bg-red-900/20 cursor-pointer transition-colors">
-                        <input
-                          type="checkbox"
-                          checked={editingUserGroup.enabledApis.includes('youtube-search')}
-                          onChange={(e) => {
-                            if (e.target.checked) {
-                              setEditingUserGroup(prev => prev ? {
-                                ...prev,
-                                enabledApis: [...prev.enabledApis, 'youtube-search']
-                              } : null);
-                            } else {
-                              setEditingUserGroup(prev => prev ? {
-                                ...prev,
-                                enabledApis: prev.enabledApis.filter(api => api !== 'youtube-search')
-                              } : null);
-                            }
-                          }}
-                          className="rounded border-red-300 text-red-600 focus:ring-red-500 dark:border-red-600 dark:bg-red-700"
-                        />
-                        <div className="flex-1">
-                          <div className="text-sm font-medium text-red-900 dark:text-red-100">
-                            📺 YouTube搜索功能
-                          </div>
-                          <div className="text-xs text-red-700 dark:text-red-300">
-                            搜索和推荐YouTube视频 (消耗YouTube API配额)
-                          </div>
-                        </div>
-                      </label>
-                    </div>
-                  </div>
-
-                  {/* 快速操作按钮 */}
-                  <div className='mt-4 flex space-x-2'>
-                    <button
-                      onClick={() => setEditingUserGroup(prev => prev ? { ...prev, enabledApis: [] } : null)}
-                      className={buttonStyles.quickAction}
-                    >
-                      全不选（无限制）
-                    </button>
-                    <button
-                      onClick={() => {
-                        const allApis = config?.SourceConfig?.filter(source => !source.disabled).map(s => s.key) || [];
-                        const specialFeatures = ['ai-recommend', 'youtube-search'];
-                        setEditingUserGroup(prev => prev ? { ...prev, enabledApis: [...allApis, ...specialFeatures] } : null);
-                      }}
-                      className={buttonStyles.quickAction}
-                    >
-                      全选
-                    </button>
-                  </div>
-                </div>
-
-                {/* 成人内容控制 */}
-                <div className='p-4 bg-gradient-to-r from-red-50 to-pink-50 dark:from-red-900/20 dark:to-pink-900/20 rounded-lg border border-red-200 dark:border-red-800'>
-                  <label className='flex items-center justify-between cursor-pointer'>
-                    <div className='flex-1'>
-                      <div className='flex items-center space-x-2'>
-                        <span className='text-base font-medium text-gray-900 dark:text-gray-100'>
-                          显示成人内容
-                        </span>
-                        <span className='text-lg'>🔞</span>
-                      </div>
-                      <p className='text-sm text-gray-600 dark:text-gray-400 mt-1'>
-                        允许此用户组查看被标记为成人资源的视频源（需要同时启用站点级别的成人内容开关）
-                      </p>
-                    </div>
-                    <div className='relative inline-block ml-4'>
-                      <input
-                        type='checkbox'
-                        checked={editingUserGroup?.showAdultContent || false}
-                        onChange={(e) =>
-                          setEditingUserGroup((prev) => prev ? ({
-                            ...prev,
-                            showAdultContent: e.target.checked,
-                          }) : null)
-                        }
-                        className='sr-only peer'
-                      />
-                      <div className='w-14 h-7 bg-gray-300 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-red-300 dark:peer-focus:ring-red-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[""] after:absolute after:top-0.5 after:start-[4px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-6 after:w-6 after:transition-all dark:border-gray-600 peer-checked:bg-gradient-to-r peer-checked:from-red-600 peer-checked:to-pink-600'></div>
-                    </div>
-                  </label>
-                </div>
-
-                {/* 操作按钮 */}
-                <div className='flex justify-end space-x-3 pt-4 border-t border-gray-200 dark:border-gray-700'>
-                  <button
-                    onClick={() => {
-                      setShowEditUserGroupForm(false);
-                      setEditingUserGroup(null);
-                    }}
-                    className={`px-6 py-2.5 text-sm font-medium ${buttonStyles.secondary}`}
-                  >
-                    取消
-                  </button>
-                  <button
-                    onClick={handleEditUserGroup}
-                    disabled={isLoading(`userGroup_edit_${editingUserGroup?.name}`)}
-                    className={`px-6 py-2.5 text-sm font-medium ${isLoading(`userGroup_edit_${editingUserGroup?.name}`) ? buttonStyles.disabled : buttonStyles.primary}`}
-                  >
-                    {isLoading(`userGroup_edit_${editingUserGroup?.name}`) ? '保存中...' : '保存修改'}
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>,
-        document.body
-      )}
-
-      {/* 配置用户组弹窗 */}
-      {showConfigureUserGroupModal && selectedUserForGroup && createPortal(
-        <div className='fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4' onClick={() => {
-          setShowConfigureUserGroupModal(false);
-          setSelectedUserForGroup(null);
-          setSelectedUserGroups([]);
-        }}>
-          <div className='bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-4xl w-full max-h-[80vh] overflow-y-auto' onClick={(e) => e.stopPropagation()}>
-            <div className='p-6'>
-              <div className='flex items-center justify-between mb-6'>
-                <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
-                  配置用户组 - {selectedUserForGroup.username}
-                </h3>
-                <button
-                  onClick={() => {
-                    setShowConfigureUserGroupModal(false);
-                    setSelectedUserForGroup(null);
-                    setSelectedUserGroups([]);
-                  }}
-                  className='text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors'
-                >
-                  <svg className='w-6 h-6' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                    <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M6 18L18 6M6 6l12 12' />
-                  </svg>
-                </button>
-              </div>
-
-              <div className='mb-6'>
-                <div className='bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4'>
-                  <div className='flex items-center space-x-2 mb-2'>
-                    <svg className='w-5 h-5 text-blue-600 dark:text-blue-400' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                      <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z' />
-                    </svg>
-                    <span className='text-sm font-medium text-blue-800 dark:text-blue-300'>
-                      配置说明
-                    </span>
-                  </div>
-                  <p className='text-sm text-blue-700 dark:text-blue-400 mt-1'>
-                    提示：选择"无用户组"为无限制，选择特定用户组将限制用户只能访问该用户组允许的采集源
-                  </p>
-                </div>
-              </div>
-
-              {/* 用户组选择 - 下拉选择器 */}
-              <div className='mb-6'>
-                <label className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'>
-                  选择用户组：
-                </label>
-                <select
-                  value={selectedUserGroups.length > 0 ? selectedUserGroups[0] : ''}
-                  onChange={(e) => {
-                    const value = e.target.value;
-                    setSelectedUserGroups(value ? [value] : []);
-                  }}
-                  className='w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors'
-                >
-                  <option value=''>无用户组（无限制）</option>
-                  {userGroups.map((group) => (
-                    <option key={group.name} value={group.name}>
-                      {group.name} {group.enabledApis && group.enabledApis.length > 0 ? `(${group.enabledApis.length} 个源)` : ''}
-                    </option>
-                  ))}
-                </select>
-                <p className='mt-2 text-xs text-gray-500 dark:text-gray-400'>
-                  选择"无用户组"为无限制，选择特定用户组将限制用户只能访问该用户组允许的采集源
-                </p>
-              </div>
-
-
-
-              {/* 操作按钮 */}
-              <div className='flex justify-end space-x-3'>
-                <button
-                  onClick={() => {
-                    setShowConfigureUserGroupModal(false);
-                    setSelectedUserForGroup(null);
-                    setSelectedUserGroups([]);
-                  }}
-                  className={`px-6 py-2.5 text-sm font-medium ${buttonStyles.secondary}`}
-                >
-                  取消
-                </button>
-                <button
-                  onClick={handleSaveUserGroups}
-                  disabled={isLoading(`saveUserGroups_${selectedUserForGroup?.username}`)}
-                  className={`px-6 py-2.5 text-sm font-medium ${isLoading(`saveUserGroups_${selectedUserForGroup?.username}`) ? buttonStyles.disabled : buttonStyles.primary}`}
-                >
-                  {isLoading(`saveUserGroups_${selectedUserForGroup?.username}`) ? '配置中...' : '确认配置'}
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>,
-        document.body
-      )}
-
-      {/* 删除用户组确认弹窗 */}
-      {showDeleteUserGroupModal && deletingUserGroup && createPortal(
-        <div className='fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4' onClick={() => {
-          setShowDeleteUserGroupModal(false);
-          setDeletingUserGroup(null);
-        }}>
-          <div className='bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-2xl w-full' onClick={(e) => e.stopPropagation()}>
-            <div className='p-6'>
-              <div className='flex items-center justify-between mb-6'>
-                <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
-                  确认删除用户组
-                </h3>
-                <button
-                  onClick={() => {
-                    setShowDeleteUserGroupModal(false);
-                    setDeletingUserGroup(null);
-                  }}
-                  className='text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors'
-                >
-                  <svg className='w-6 h-6' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                    <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M6 18L18 6M6 6l12 12' />
-                  </svg>
-                </button>
-              </div>
-
-              <div className='mb-6'>
-                <div className='bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 mb-4'>
-                  <div className='flex items-center space-x-2 mb-2'>
-                    <svg className='w-5 h-5 text-red-600 dark:text-red-400' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                      <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z' />
-                    </svg>
-                    <span className='text-sm font-medium text-red-800 dark:text-red-300'>
-                      危险操作警告
-                    </span>
-                  </div>
-                  <p className='text-sm text-red-700 dark:text-red-400'>
-                    删除用户组 <strong>{deletingUserGroup.name}</strong> 将影响所有使用该组的用户，此操作不可恢复！
-                  </p>
-                </div>
-
-                {deletingUserGroup.affectedUsers.length > 0 ? (
-                  <div className='bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4'>
-                    <div className='flex items-center space-x-2 mb-2'>
-                      <svg className='w-5 h-5 text-yellow-600 dark:text-yellow-400' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                        <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z' />
-                      </svg>
-                      <span className='text-sm font-medium text-yellow-800 dark:text-yellow-300'>
-                        ⚠️ 将影响 {deletingUserGroup.affectedUsers.length} 个用户：
-                      </span>
-                    </div>
-                    <div className='space-y-1'>
-                      {deletingUserGroup.affectedUsers.map((user, index) => (
-                        <div key={index} className='text-sm text-yellow-700 dark:text-yellow-300'>
-                          • {user.username} ({user.role})
-                        </div>
-                      ))}
-                    </div>
-                    <p className='text-xs text-yellow-600 dark:text-yellow-400 mt-2'>
-                      这些用户的用户组将被自动移除
-                    </p>
-                  </div>
-                ) : (
-                  <div className='bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-4'>
-                    <div className='flex items-center space-x-2'>
-                      <svg className='w-5 h-5 text-green-600 dark:text-green-400' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                        <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M5 13l4 4L19 7' />
-                      </svg>
-                      <span className='text-sm font-medium text-green-800 dark:text-green-300'>
-                        ✅ 当前没有用户使用此用户组
-                      </span>
-                    </div>
-                  </div>
-                )}
-              </div>
-
-              {/* 操作按钮 */}
-              <div className='flex justify-end space-x-3'>
-                <button
-                  onClick={() => {
-                    setShowDeleteUserGroupModal(false);
-                    setDeletingUserGroup(null);
-                  }}
-                  className={`px-6 py-2.5 text-sm font-medium ${buttonStyles.secondary}`}
-                >
-                  取消
-                </button>
-                <button
-                  onClick={handleConfirmDeleteUserGroup}
-                  disabled={isLoading(`userGroup_delete_${deletingUserGroup?.name}`)}
-                  className={`px-6 py-2.5 text-sm font-medium ${isLoading(`userGroup_delete_${deletingUserGroup?.name}`) ? buttonStyles.disabled : buttonStyles.danger}`}
-                >
-                  {isLoading(`userGroup_delete_${deletingUserGroup?.name}`) ? '删除中...' : '确认删除'}
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>,
-        document.body
-      )}
-
-      {/* 删除用户确认弹窗 */}
-      {showDeleteUserModal && deletingUser && createPortal(
-        <div className='fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4' onClick={() => {
-          setShowDeleteUserModal(false);
-          setDeletingUser(null);
-        }}>
-          <div className='bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-2xl w-full' onClick={(e) => e.stopPropagation()}>
-            <div className='p-6'>
-              <div className='flex items-center justify-between mb-6'>
-                <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
-                  确认删除用户
-                </h3>
-                <button
-                  onClick={() => {
-                    setShowDeleteUserModal(false);
-                    setDeletingUser(null);
-                  }}
-                  className='text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors'
-                >
-                  <svg className='w-6 h-6' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                    <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M6 18L18 6M6 6l12 12' />
-                  </svg>
-                </button>
-              </div>
-
-              <div className='mb-6'>
-                <div className='bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 mb-4'>
-                  <div className='flex items-center space-x-2 mb-2'>
-                    <svg className='w-5 h-5 text-red-600 dark:text-red-400' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                      <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z' />
-                    </svg>
-                    <span className='text-sm font-medium text-red-800 dark:text-red-300'>
-                      危险操作警告
-                    </span>
-                  </div>
-                  <p className='text-sm text-red-700 dark:text-red-400'>
-                    删除用户 <strong>{deletingUser}</strong> 将同时删除其搜索历史、播放记录和收藏夹，此操作不可恢复！
-                  </p>
                 </div>
 
                 {/* 操作按钮 */}
                 <div className='flex justify-end space-x-3'>
                   <button
                     onClick={() => {
-                      setShowDeleteUserModal(false);
-                      setDeletingUser(null);
+                      setShowConfigureApisModal(false);
+                      setSelectedUser(null);
+                      setSelectedApis([]);
+                      setSelectedShowAdultContent(false);
                     }}
                     className={`px-6 py-2.5 text-sm font-medium ${buttonStyles.secondary}`}
                   >
                     取消
                   </button>
                   <button
-                    onClick={handleConfirmDeleteUser}
-                    className={`px-6 py-2.5 text-sm font-medium ${buttonStyles.danger}`}
+                    onClick={handleSaveUserApis}
+                    disabled={isLoading(
+                      `saveUserApis_${selectedUser?.username}`
+                    )}
+                    className={`px-6 py-2.5 text-sm font-medium ${
+                      isLoading(`saveUserApis_${selectedUser?.username}`)
+                        ? buttonStyles.disabled
+                        : buttonStyles.primary
+                    }`}
                   >
-                    确认删除
+                    {isLoading(`saveUserApis_${selectedUser?.username}`)
+                      ? '配置中...'
+                      : '确认配置'}
                   </button>
                 </div>
               </div>
             </div>
-          </div>
-        </div>,
-        document.body
-      )}
+          </div>,
+          document.body
+        )}
 
-      {/* TVBox Token 管理弹窗 */}
-      {showTVBoxTokenModal && tvboxTokenUser && createPortal(
-        <TVBoxTokenModal
-          username={tvboxTokenUser.username}
-          tvboxToken={tvboxTokenUser.tvboxToken}
-          tvboxEnabledSources={selectedTVBoxSources}
-          allSources={(config?.SourceConfig || []).filter(s => !s.disabled).map(s => ({ key: s.key, name: s.name }))}
-          onClose={() => {
-            setShowTVBoxTokenModal(false);
-            setTVBoxTokenUser(null);
-            setSelectedTVBoxSources([]);
-          }}
-          onUpdate={refreshConfig}
-        />,
-        document.body
-      )}
-
-      {/* 批量设置用户组弹窗 */}
-      {showBatchUserGroupModal && createPortal(
-        <div className='fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4' onClick={() => {
-          setShowBatchUserGroupModal(false);
-          setSelectedUserGroup('');
-        }}>
-          <div className='bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-2xl w-full' onClick={(e) => e.stopPropagation()}>
-            <div className='p-6'>
-              <div className='flex items-center justify-between mb-6'>
-                <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
-                  批量设置用户组
-                </h3>
-                <button
-                  onClick={() => {
-                    setShowBatchUserGroupModal(false);
-                    setSelectedUserGroup('');
-                  }}
-                  className='text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors'
-                >
-                  <svg className='w-6 h-6' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                    <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M6 18L18 6M6 6l12 12' />
-                  </svg>
-                </button>
-              </div>
-
-              <div className='mb-6'>
-                <div className='bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4 mb-4'>
-                  <div className='flex items-center space-x-2 mb-2'>
-                    <svg className='w-5 h-5 text-blue-600 dark:text-blue-400' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                      <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z' />
+      {/* 添加用户组弹窗 */}
+      {showAddUserGroupForm &&
+        createPortal(
+          <div
+            className='fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4'
+            onClick={() => {
+              setShowAddUserGroupForm(false);
+              setNewUserGroup({
+                name: '',
+                enabledApis: [],
+                showAdultContent: false,
+              });
+            }}
+          >
+            <div
+              className='bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-4xl w-full max-h-[80vh] overflow-y-auto'
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className='p-6'>
+                <div className='flex items-center justify-between mb-6'>
+                  <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
+                    添加新用户组
+                  </h3>
+                  <button
+                    onClick={() => {
+                      setShowAddUserGroupForm(false);
+                      setNewUserGroup({
+                        name: '',
+                        enabledApis: [],
+                        showAdultContent: false,
+                      });
+                    }}
+                    className='text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors'
+                  >
+                    <svg
+                      className='w-6 h-6'
+                      fill='none'
+                      stroke='currentColor'
+                      viewBox='0 0 24 24'
+                    >
+                      <path
+                        strokeLinecap='round'
+                        strokeLinejoin='round'
+                        strokeWidth={2}
+                        d='M6 18L18 6M6 6l12 12'
+                      />
                     </svg>
-                    <span className='text-sm font-medium text-blue-800 dark:text-blue-300'>
-                      批量操作说明
-                    </span>
-                  </div>
-                  <p className='text-sm text-blue-700 dark:text-blue-400'>
-                    将为选中的 <strong>{selectedUsers.size} 个用户</strong> 设置用户组，选择"无用户组"为无限制
-                  </p>
+                  </button>
                 </div>
 
-                <div>
+                <div className='space-y-6'>
+                  {/* 用户组名称 */}
+                  <div>
+                    <label className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'>
+                      用户组名称
+                    </label>
+                    <input
+                      type='text'
+                      placeholder='请输入用户组名称'
+                      value={newUserGroup.name}
+                      onChange={(e) =>
+                        setNewUserGroup((prev) => ({
+                          ...prev,
+                          name: e.target.value,
+                        }))
+                      }
+                      className='w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent'
+                    />
+                  </div>
+
+                  {/* 可用视频源 */}
+                  <div>
+                    <label className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-4'>
+                      可用视频源
+                    </label>
+                    <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3'>
+                      {config?.SourceConfig?.map((source) => (
+                        <label
+                          key={source.key}
+                          className='flex items-center space-x-3 p-3 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer transition-colors'
+                        >
+                          <input
+                            type='checkbox'
+                            checked={newUserGroup.enabledApis.includes(
+                              source.key
+                            )}
+                            onChange={(e) => {
+                              if (e.target.checked) {
+                                setNewUserGroup((prev) => ({
+                                  ...prev,
+                                  enabledApis: [
+                                    ...prev.enabledApis,
+                                    source.key,
+                                  ],
+                                }));
+                              } else {
+                                setNewUserGroup((prev) => ({
+                                  ...prev,
+                                  enabledApis: prev.enabledApis.filter(
+                                    (api) => api !== source.key
+                                  ),
+                                }));
+                              }
+                            }}
+                            className='rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700'
+                          />
+                          <div className='flex-1 min-w-0'>
+                            <div className='text-sm font-medium text-gray-900 dark:text-gray-100 truncate'>
+                              {source.name}
+                            </div>
+                            {source.api && (
+                              <div className='text-xs text-gray-500 dark:text-gray-400 truncate'>
+                                {extractDomain(source.api)}
+                              </div>
+                            )}
+                          </div>
+                        </label>
+                      ))}
+                    </div>
+
+                    {/* 特殊功能权限 */}
+                    <div className='mt-6 pt-6 border-t border-gray-200 dark:border-gray-700'>
+                      <label className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-3'>
+                        特殊功能权限
+                      </label>
+                      <div className='space-y-3'>
+                        {/* AI推荐功能 */}
+                        <label className='flex items-center space-x-3 p-3 border border-orange-200 dark:border-orange-700 rounded-lg bg-orange-50 dark:bg-orange-900/10 hover:bg-orange-100 dark:hover:bg-orange-900/20 cursor-pointer transition-colors'>
+                          <input
+                            type='checkbox'
+                            checked={newUserGroup.enabledApis.includes(
+                              'ai-recommend'
+                            )}
+                            onChange={(e) => {
+                              if (e.target.checked) {
+                                setNewUserGroup((prev) => ({
+                                  ...prev,
+                                  enabledApis: [
+                                    ...prev.enabledApis,
+                                    'ai-recommend',
+                                  ],
+                                }));
+                              } else {
+                                setNewUserGroup((prev) => ({
+                                  ...prev,
+                                  enabledApis: prev.enabledApis.filter(
+                                    (api) => api !== 'ai-recommend'
+                                  ),
+                                }));
+                              }
+                            }}
+                            className='rounded border-orange-300 text-orange-600 focus:ring-orange-500 dark:border-orange-600 dark:bg-orange-700'
+                          />
+                          <div className='flex-1'>
+                            <div className='text-sm font-medium text-orange-900 dark:text-orange-100'>
+                              🤖 AI推荐功能
+                            </div>
+                            <div className='text-xs text-orange-700 dark:text-orange-300'>
+                              智能推荐影视内容 (消耗OpenAI API费用)
+                            </div>
+                          </div>
+                        </label>
+
+                        {/* YouTube搜索功能 */}
+                        <label className='flex items-center space-x-3 p-3 border border-red-200 dark:border-red-700 rounded-lg bg-red-50 dark:bg-red-900/10 hover:bg-red-100 dark:hover:bg-red-900/20 cursor-pointer transition-colors'>
+                          <input
+                            type='checkbox'
+                            checked={newUserGroup.enabledApis.includes(
+                              'youtube-search'
+                            )}
+                            onChange={(e) => {
+                              if (e.target.checked) {
+                                setNewUserGroup((prev) => ({
+                                  ...prev,
+                                  enabledApis: [
+                                    ...prev.enabledApis,
+                                    'youtube-search',
+                                  ],
+                                }));
+                              } else {
+                                setNewUserGroup((prev) => ({
+                                  ...prev,
+                                  enabledApis: prev.enabledApis.filter(
+                                    (api) => api !== 'youtube-search'
+                                  ),
+                                }));
+                              }
+                            }}
+                            className='rounded border-red-300 text-red-600 focus:ring-red-500 dark:border-red-600 dark:bg-red-700'
+                          />
+                          <div className='flex-1'>
+                            <div className='text-sm font-medium text-red-900 dark:text-red-100'>
+                              📺 YouTube搜索功能
+                            </div>
+                            <div className='text-xs text-red-700 dark:text-red-300'>
+                              搜索和推荐YouTube视频 (消耗YouTube API配额)
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                    </div>
+
+                    {/* 快速操作按钮 */}
+                    <div className='mt-4 flex space-x-2'>
+                      <button
+                        onClick={() =>
+                          setNewUserGroup((prev) => ({
+                            ...prev,
+                            enabledApis: [],
+                          }))
+                        }
+                        className={buttonStyles.quickAction}
+                      >
+                        全不选（无限制）
+                      </button>
+                      <button
+                        onClick={() => {
+                          const allApis =
+                            config?.SourceConfig?.filter(
+                              (source) => !source.disabled
+                            ).map((s) => s.key) || [];
+                          const specialFeatures = [
+                            'ai-recommend',
+                            'youtube-search',
+                          ];
+                          setNewUserGroup((prev) => ({
+                            ...prev,
+                            enabledApis: [...allApis, ...specialFeatures],
+                          }));
+                        }}
+                        className={buttonStyles.quickAction}
+                      >
+                        全选
+                      </button>
+                    </div>
+                  </div>
+
+                  {/* 成人内容控制 */}
+                  <div className='p-4 bg-gradient-to-r from-red-50 to-pink-50 dark:from-red-900/20 dark:to-pink-900/20 rounded-lg border border-red-200 dark:border-red-800'>
+                    <label className='flex items-center justify-between cursor-pointer'>
+                      <div className='flex-1'>
+                        <div className='flex items-center space-x-2'>
+                          <span className='text-base font-medium text-gray-900 dark:text-gray-100'>
+                            显示成人内容
+                          </span>
+                          <span className='text-lg'>🔞</span>
+                        </div>
+                        <p className='text-sm text-gray-600 dark:text-gray-400 mt-1'>
+                          允许此用户组查看被标记为成人资源的视频源（需要同时启用站点级别的成人内容开关）
+                        </p>
+                      </div>
+                      <div className='relative inline-block ml-4'>
+                        <input
+                          type='checkbox'
+                          checked={newUserGroup.showAdultContent}
+                          onChange={(e) =>
+                            setNewUserGroup((prev) => ({
+                              ...prev,
+                              showAdultContent: e.target.checked,
+                            }))
+                          }
+                          className='sr-only peer'
+                        />
+                        <div className='w-14 h-7 bg-gray-300 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-red-300 dark:peer-focus:ring-red-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[""] after:absolute after:top-0.5 after:start-[4px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-6 after:w-6 after:transition-all dark:border-gray-600 peer-checked:bg-gradient-to-r peer-checked:from-red-600 peer-checked:to-pink-600'></div>
+                      </div>
+                    </label>
+                  </div>
+
+                  {/* 操作按钮 */}
+                  <div className='flex justify-end space-x-3 pt-4 border-t border-gray-200 dark:border-gray-700'>
+                    <button
+                      onClick={() => {
+                        setShowAddUserGroupForm(false);
+                        setNewUserGroup({
+                          name: '',
+                          enabledApis: [],
+                          showAdultContent: false,
+                        });
+                      }}
+                      className={`px-6 py-2.5 text-sm font-medium ${buttonStyles.secondary}`}
+                    >
+                      取消
+                    </button>
+                    <button
+                      onClick={handleAddUserGroup}
+                      disabled={
+                        !newUserGroup.name.trim() ||
+                        isLoading('userGroup_add_new')
+                      }
+                      className={`px-6 py-2.5 text-sm font-medium ${
+                        !newUserGroup.name.trim() ||
+                        isLoading('userGroup_add_new')
+                          ? buttonStyles.disabled
+                          : buttonStyles.primary
+                      }`}
+                    >
+                      {isLoading('userGroup_add_new')
+                        ? '添加中...'
+                        : '添加用户组'}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>,
+          document.body
+        )}
+
+      {/* 编辑用户组弹窗 */}
+      {showEditUserGroupForm &&
+        editingUserGroup &&
+        createPortal(
+          <div
+            className='fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4'
+            onClick={() => {
+              setShowEditUserGroupForm(false);
+              setEditingUserGroup(null);
+            }}
+          >
+            <div
+              className='bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-4xl w-full max-h-[80vh] overflow-y-auto'
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className='p-6'>
+                <div className='flex items-center justify-between mb-6'>
+                  <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
+                    编辑用户组 - {editingUserGroup.name}
+                  </h3>
+                  <button
+                    onClick={() => {
+                      setShowEditUserGroupForm(false);
+                      setEditingUserGroup(null);
+                    }}
+                    className='text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors'
+                  >
+                    <svg
+                      className='w-6 h-6'
+                      fill='none'
+                      stroke='currentColor'
+                      viewBox='0 0 24 24'
+                    >
+                      <path
+                        strokeLinecap='round'
+                        strokeLinejoin='round'
+                        strokeWidth={2}
+                        d='M6 18L18 6M6 6l12 12'
+                      />
+                    </svg>
+                  </button>
+                </div>
+
+                <div className='space-y-6'>
+                  {/* 可用视频源 */}
+                  <div>
+                    <label className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-4'>
+                      可用视频源
+                    </label>
+                    <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3'>
+                      {config?.SourceConfig?.map((source) => (
+                        <label
+                          key={source.key}
+                          className='flex items-center space-x-3 p-3 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer transition-colors'
+                        >
+                          <input
+                            type='checkbox'
+                            checked={editingUserGroup.enabledApis.includes(
+                              source.key
+                            )}
+                            onChange={(e) => {
+                              if (e.target.checked) {
+                                setEditingUserGroup((prev) =>
+                                  prev
+                                    ? {
+                                        ...prev,
+                                        enabledApis: [
+                                          ...prev.enabledApis,
+                                          source.key,
+                                        ],
+                                      }
+                                    : null
+                                );
+                              } else {
+                                setEditingUserGroup((prev) =>
+                                  prev
+                                    ? {
+                                        ...prev,
+                                        enabledApis: prev.enabledApis.filter(
+                                          (api) => api !== source.key
+                                        ),
+                                      }
+                                    : null
+                                );
+                              }
+                            }}
+                            className='rounded border-gray-300 text-purple-600 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-700'
+                          />
+                          <div className='flex-1 min-w-0'>
+                            <div className='text-sm font-medium text-gray-900 dark:text-gray-100 truncate'>
+                              {source.name}
+                            </div>
+                            {source.api && (
+                              <div className='text-xs text-gray-500 dark:text-gray-400 truncate'>
+                                {extractDomain(source.api)}
+                              </div>
+                            )}
+                          </div>
+                        </label>
+                      ))}
+                    </div>
+
+                    {/* 特殊功能权限 */}
+                    <div className='mt-6 pt-6 border-t border-gray-200 dark:border-gray-700'>
+                      <label className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-3'>
+                        特殊功能权限
+                      </label>
+                      <div className='space-y-3'>
+                        {/* AI推荐功能 */}
+                        <label className='flex items-center space-x-3 p-3 border border-orange-200 dark:border-orange-700 rounded-lg bg-orange-50 dark:bg-orange-900/10 hover:bg-orange-100 dark:hover:bg-orange-900/20 cursor-pointer transition-colors'>
+                          <input
+                            type='checkbox'
+                            checked={editingUserGroup.enabledApis.includes(
+                              'ai-recommend'
+                            )}
+                            onChange={(e) => {
+                              if (e.target.checked) {
+                                setEditingUserGroup((prev) =>
+                                  prev
+                                    ? {
+                                        ...prev,
+                                        enabledApis: [
+                                          ...prev.enabledApis,
+                                          'ai-recommend',
+                                        ],
+                                      }
+                                    : null
+                                );
+                              } else {
+                                setEditingUserGroup((prev) =>
+                                  prev
+                                    ? {
+                                        ...prev,
+                                        enabledApis: prev.enabledApis.filter(
+                                          (api) => api !== 'ai-recommend'
+                                        ),
+                                      }
+                                    : null
+                                );
+                              }
+                            }}
+                            className='rounded border-orange-300 text-orange-600 focus:ring-orange-500 dark:border-orange-600 dark:bg-orange-700'
+                          />
+                          <div className='flex-1'>
+                            <div className='text-sm font-medium text-orange-900 dark:text-orange-100'>
+                              🤖 AI推荐功能
+                            </div>
+                            <div className='text-xs text-orange-700 dark:text-orange-300'>
+                              智能推荐影视内容 (消耗OpenAI API费用)
+                            </div>
+                          </div>
+                        </label>
+
+                        {/* YouTube搜索功能 */}
+                        <label className='flex items-center space-x-3 p-3 border border-red-200 dark:border-red-700 rounded-lg bg-red-50 dark:bg-red-900/10 hover:bg-red-100 dark:hover:bg-red-900/20 cursor-pointer transition-colors'>
+                          <input
+                            type='checkbox'
+                            checked={editingUserGroup.enabledApis.includes(
+                              'youtube-search'
+                            )}
+                            onChange={(e) => {
+                              if (e.target.checked) {
+                                setEditingUserGroup((prev) =>
+                                  prev
+                                    ? {
+                                        ...prev,
+                                        enabledApis: [
+                                          ...prev.enabledApis,
+                                          'youtube-search',
+                                        ],
+                                      }
+                                    : null
+                                );
+                              } else {
+                                setEditingUserGroup((prev) =>
+                                  prev
+                                    ? {
+                                        ...prev,
+                                        enabledApis: prev.enabledApis.filter(
+                                          (api) => api !== 'youtube-search'
+                                        ),
+                                      }
+                                    : null
+                                );
+                              }
+                            }}
+                            className='rounded border-red-300 text-red-600 focus:ring-red-500 dark:border-red-600 dark:bg-red-700'
+                          />
+                          <div className='flex-1'>
+                            <div className='text-sm font-medium text-red-900 dark:text-red-100'>
+                              📺 YouTube搜索功能
+                            </div>
+                            <div className='text-xs text-red-700 dark:text-red-300'>
+                              搜索和推荐YouTube视频 (消耗YouTube API配额)
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                    </div>
+
+                    {/* 快速操作按钮 */}
+                    <div className='mt-4 flex space-x-2'>
+                      <button
+                        onClick={() =>
+                          setEditingUserGroup((prev) =>
+                            prev ? { ...prev, enabledApis: [] } : null
+                          )
+                        }
+                        className={buttonStyles.quickAction}
+                      >
+                        全不选（无限制）
+                      </button>
+                      <button
+                        onClick={() => {
+                          const allApis =
+                            config?.SourceConfig?.filter(
+                              (source) => !source.disabled
+                            ).map((s) => s.key) || [];
+                          const specialFeatures = [
+                            'ai-recommend',
+                            'youtube-search',
+                          ];
+                          setEditingUserGroup((prev) =>
+                            prev
+                              ? {
+                                  ...prev,
+                                  enabledApis: [...allApis, ...specialFeatures],
+                                }
+                              : null
+                          );
+                        }}
+                        className={buttonStyles.quickAction}
+                      >
+                        全选
+                      </button>
+                    </div>
+                  </div>
+
+                  {/* 成人内容控制 */}
+                  <div className='p-4 bg-gradient-to-r from-red-50 to-pink-50 dark:from-red-900/20 dark:to-pink-900/20 rounded-lg border border-red-200 dark:border-red-800'>
+                    <label className='flex items-center justify-between cursor-pointer'>
+                      <div className='flex-1'>
+                        <div className='flex items-center space-x-2'>
+                          <span className='text-base font-medium text-gray-900 dark:text-gray-100'>
+                            显示成人内容
+                          </span>
+                          <span className='text-lg'>🔞</span>
+                        </div>
+                        <p className='text-sm text-gray-600 dark:text-gray-400 mt-1'>
+                          允许此用户组查看被标记为成人资源的视频源（需要同时启用站点级别的成人内容开关）
+                        </p>
+                      </div>
+                      <div className='relative inline-block ml-4'>
+                        <input
+                          type='checkbox'
+                          checked={editingUserGroup?.showAdultContent || false}
+                          onChange={(e) =>
+                            setEditingUserGroup((prev) =>
+                              prev
+                                ? {
+                                    ...prev,
+                                    showAdultContent: e.target.checked,
+                                  }
+                                : null
+                            )
+                          }
+                          className='sr-only peer'
+                        />
+                        <div className='w-14 h-7 bg-gray-300 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-red-300 dark:peer-focus:ring-red-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[""] after:absolute after:top-0.5 after:start-[4px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-6 after:w-6 after:transition-all dark:border-gray-600 peer-checked:bg-gradient-to-r peer-checked:from-red-600 peer-checked:to-pink-600'></div>
+                      </div>
+                    </label>
+                  </div>
+
+                  {/* 操作按钮 */}
+                  <div className='flex justify-end space-x-3 pt-4 border-t border-gray-200 dark:border-gray-700'>
+                    <button
+                      onClick={() => {
+                        setShowEditUserGroupForm(false);
+                        setEditingUserGroup(null);
+                      }}
+                      className={`px-6 py-2.5 text-sm font-medium ${buttonStyles.secondary}`}
+                    >
+                      取消
+                    </button>
+                    <button
+                      onClick={handleEditUserGroup}
+                      disabled={isLoading(
+                        `userGroup_edit_${editingUserGroup?.name}`
+                      )}
+                      className={`px-6 py-2.5 text-sm font-medium ${
+                        isLoading(`userGroup_edit_${editingUserGroup?.name}`)
+                          ? buttonStyles.disabled
+                          : buttonStyles.primary
+                      }`}
+                    >
+                      {isLoading(`userGroup_edit_${editingUserGroup?.name}`)
+                        ? '保存中...'
+                        : '保存修改'}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>,
+          document.body
+        )}
+
+      {/* 配置用户组弹窗 */}
+      {showConfigureUserGroupModal &&
+        selectedUserForGroup &&
+        createPortal(
+          <div
+            className='fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4'
+            onClick={() => {
+              setShowConfigureUserGroupModal(false);
+              setSelectedUserForGroup(null);
+              setSelectedUserGroups([]);
+            }}
+          >
+            <div
+              className='bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-4xl w-full max-h-[80vh] overflow-y-auto'
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className='p-6'>
+                <div className='flex items-center justify-between mb-6'>
+                  <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
+                    配置用户组 - {selectedUserForGroup.username}
+                  </h3>
+                  <button
+                    onClick={() => {
+                      setShowConfigureUserGroupModal(false);
+                      setSelectedUserForGroup(null);
+                      setSelectedUserGroups([]);
+                    }}
+                    className='text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors'
+                  >
+                    <svg
+                      className='w-6 h-6'
+                      fill='none'
+                      stroke='currentColor'
+                      viewBox='0 0 24 24'
+                    >
+                      <path
+                        strokeLinecap='round'
+                        strokeLinejoin='round'
+                        strokeWidth={2}
+                        d='M6 18L18 6M6 6l12 12'
+                      />
+                    </svg>
+                  </button>
+                </div>
+
+                <div className='mb-6'>
+                  <div className='bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4'>
+                    <div className='flex items-center space-x-2 mb-2'>
+                      <svg
+                        className='w-5 h-5 text-blue-600 dark:text-blue-400'
+                        fill='none'
+                        stroke='currentColor'
+                        viewBox='0 0 24 24'
+                      >
+                        <path
+                          strokeLinecap='round'
+                          strokeLinejoin='round'
+                          strokeWidth={2}
+                          d='M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z'
+                        />
+                      </svg>
+                      <span className='text-sm font-medium text-blue-800 dark:text-blue-300'>
+                        配置说明
+                      </span>
+                    </div>
+                    <p className='text-sm text-blue-700 dark:text-blue-400 mt-1'>
+                      提示：选择"无用户组"为无限制，选择特定用户组将限制用户只能访问该用户组允许的采集源
+                    </p>
+                  </div>
+                </div>
+
+                {/* 用户组选择 - 下拉选择器 */}
+                <div className='mb-6'>
                   <label className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'>
                     选择用户组：
                   </label>
                   <select
-                    onChange={(e) => setSelectedUserGroup(e.target.value)}
+                    value={
+                      selectedUserGroups.length > 0 ? selectedUserGroups[0] : ''
+                    }
+                    onChange={(e) => {
+                      const value = e.target.value;
+                      setSelectedUserGroups(value ? [value] : []);
+                    }}
                     className='w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors'
-                    value={selectedUserGroup}
                   >
                     <option value=''>无用户组（无限制）</option>
                     {userGroups.map((group) => (
                       <option key={group.name} value={group.name}>
-                        {group.name} {group.enabledApis && group.enabledApis.length > 0 ? `(${group.enabledApis.length} 个源)` : ''}
+                        {group.name}{' '}
+                        {group.enabledApis && group.enabledApis.length > 0
+                          ? `(${group.enabledApis.length} 个源)`
+                          : ''}
                       </option>
                     ))}
                   </select>
@@ -2503,32 +2711,442 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
                     选择"无用户组"为无限制，选择特定用户组将限制用户只能访问该用户组允许的采集源
                   </p>
                 </div>
-              </div>
 
-              {/* 操作按钮 */}
-              <div className='flex justify-end space-x-3'>
-                <button
-                  onClick={() => {
-                    setShowBatchUserGroupModal(false);
-                    setSelectedUserGroup('');
-                  }}
-                  className={`px-6 py-2.5 text-sm font-medium ${buttonStyles.secondary}`}
-                >
-                  取消
-                </button>
-                <button
-                  onClick={() => handleBatchSetUserGroup(selectedUserGroup)}
-                  disabled={isLoading('batchSetUserGroup')}
-                  className={`px-6 py-2.5 text-sm font-medium ${isLoading('batchSetUserGroup') ? buttonStyles.disabled : buttonStyles.primary}`}
-                >
-                  {isLoading('batchSetUserGroup') ? '设置中...' : '确认设置'}
-                </button>
+                {/* 操作按钮 */}
+                <div className='flex justify-end space-x-3'>
+                  <button
+                    onClick={() => {
+                      setShowConfigureUserGroupModal(false);
+                      setSelectedUserForGroup(null);
+                      setSelectedUserGroups([]);
+                    }}
+                    className={`px-6 py-2.5 text-sm font-medium ${buttonStyles.secondary}`}
+                  >
+                    取消
+                  </button>
+                  <button
+                    onClick={handleSaveUserGroups}
+                    disabled={isLoading(
+                      `saveUserGroups_${selectedUserForGroup?.username}`
+                    )}
+                    className={`px-6 py-2.5 text-sm font-medium ${
+                      isLoading(
+                        `saveUserGroups_${selectedUserForGroup?.username}`
+                      )
+                        ? buttonStyles.disabled
+                        : buttonStyles.primary
+                    }`}
+                  >
+                    {isLoading(
+                      `saveUserGroups_${selectedUserForGroup?.username}`
+                    )
+                      ? '配置中...'
+                      : '确认配置'}
+                  </button>
+                </div>
               </div>
             </div>
-          </div>
-        </div>,
-        document.body
-      )}
+          </div>,
+          document.body
+        )}
+
+      {/* 删除用户组确认弹窗 */}
+      {showDeleteUserGroupModal &&
+        deletingUserGroup &&
+        createPortal(
+          <div
+            className='fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4'
+            onClick={() => {
+              setShowDeleteUserGroupModal(false);
+              setDeletingUserGroup(null);
+            }}
+          >
+            <div
+              className='bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-2xl w-full'
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className='p-6'>
+                <div className='flex items-center justify-between mb-6'>
+                  <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
+                    确认删除用户组
+                  </h3>
+                  <button
+                    onClick={() => {
+                      setShowDeleteUserGroupModal(false);
+                      setDeletingUserGroup(null);
+                    }}
+                    className='text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors'
+                  >
+                    <svg
+                      className='w-6 h-6'
+                      fill='none'
+                      stroke='currentColor'
+                      viewBox='0 0 24 24'
+                    >
+                      <path
+                        strokeLinecap='round'
+                        strokeLinejoin='round'
+                        strokeWidth={2}
+                        d='M6 18L18 6M6 6l12 12'
+                      />
+                    </svg>
+                  </button>
+                </div>
+
+                <div className='mb-6'>
+                  <div className='bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 mb-4'>
+                    <div className='flex items-center space-x-2 mb-2'>
+                      <svg
+                        className='w-5 h-5 text-red-600 dark:text-red-400'
+                        fill='none'
+                        stroke='currentColor'
+                        viewBox='0 0 24 24'
+                      >
+                        <path
+                          strokeLinecap='round'
+                          strokeLinejoin='round'
+                          strokeWidth={2}
+                          d='M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z'
+                        />
+                      </svg>
+                      <span className='text-sm font-medium text-red-800 dark:text-red-300'>
+                        危险操作警告
+                      </span>
+                    </div>
+                    <p className='text-sm text-red-700 dark:text-red-400'>
+                      删除用户组 <strong>{deletingUserGroup.name}</strong>{' '}
+                      将影响所有使用该组的用户，此操作不可恢复！
+                    </p>
+                  </div>
+
+                  {deletingUserGroup.affectedUsers.length > 0 ? (
+                    <div className='bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4'>
+                      <div className='flex items-center space-x-2 mb-2'>
+                        <svg
+                          className='w-5 h-5 text-yellow-600 dark:text-yellow-400'
+                          fill='none'
+                          stroke='currentColor'
+                          viewBox='0 0 24 24'
+                        >
+                          <path
+                            strokeLinecap='round'
+                            strokeLinejoin='round'
+                            strokeWidth={2}
+                            d='M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z'
+                          />
+                        </svg>
+                        <span className='text-sm font-medium text-yellow-800 dark:text-yellow-300'>
+                          ⚠️ 将影响 {deletingUserGroup.affectedUsers.length}{' '}
+                          个用户：
+                        </span>
+                      </div>
+                      <div className='space-y-1'>
+                        {deletingUserGroup.affectedUsers.map((user, index) => (
+                          <div
+                            key={index}
+                            className='text-sm text-yellow-700 dark:text-yellow-300'
+                          >
+                            • {user.username} ({user.role})
+                          </div>
+                        ))}
+                      </div>
+                      <p className='text-xs text-yellow-600 dark:text-yellow-400 mt-2'>
+                        这些用户的用户组将被自动移除
+                      </p>
+                    </div>
+                  ) : (
+                    <div className='bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-4'>
+                      <div className='flex items-center space-x-2'>
+                        <svg
+                          className='w-5 h-5 text-green-600 dark:text-green-400'
+                          fill='none'
+                          stroke='currentColor'
+                          viewBox='0 0 24 24'
+                        >
+                          <path
+                            strokeLinecap='round'
+                            strokeLinejoin='round'
+                            strokeWidth={2}
+                            d='M5 13l4 4L19 7'
+                          />
+                        </svg>
+                        <span className='text-sm font-medium text-green-800 dark:text-green-300'>
+                          ✅ 当前没有用户使用此用户组
+                        </span>
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                {/* 操作按钮 */}
+                <div className='flex justify-end space-x-3'>
+                  <button
+                    onClick={() => {
+                      setShowDeleteUserGroupModal(false);
+                      setDeletingUserGroup(null);
+                    }}
+                    className={`px-6 py-2.5 text-sm font-medium ${buttonStyles.secondary}`}
+                  >
+                    取消
+                  </button>
+                  <button
+                    onClick={handleConfirmDeleteUserGroup}
+                    disabled={isLoading(
+                      `userGroup_delete_${deletingUserGroup?.name}`
+                    )}
+                    className={`px-6 py-2.5 text-sm font-medium ${
+                      isLoading(`userGroup_delete_${deletingUserGroup?.name}`)
+                        ? buttonStyles.disabled
+                        : buttonStyles.danger
+                    }`}
+                  >
+                    {isLoading(`userGroup_delete_${deletingUserGroup?.name}`)
+                      ? '删除中...'
+                      : '确认删除'}
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>,
+          document.body
+        )}
+
+      {/* 删除用户确认弹窗 */}
+      {showDeleteUserModal &&
+        deletingUser &&
+        createPortal(
+          <div
+            className='fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4'
+            onClick={() => {
+              setShowDeleteUserModal(false);
+              setDeletingUser(null);
+            }}
+          >
+            <div
+              className='bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-2xl w-full'
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className='p-6'>
+                <div className='flex items-center justify-between mb-6'>
+                  <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
+                    确认删除用户
+                  </h3>
+                  <button
+                    onClick={() => {
+                      setShowDeleteUserModal(false);
+                      setDeletingUser(null);
+                    }}
+                    className='text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors'
+                  >
+                    <svg
+                      className='w-6 h-6'
+                      fill='none'
+                      stroke='currentColor'
+                      viewBox='0 0 24 24'
+                    >
+                      <path
+                        strokeLinecap='round'
+                        strokeLinejoin='round'
+                        strokeWidth={2}
+                        d='M6 18L18 6M6 6l12 12'
+                      />
+                    </svg>
+                  </button>
+                </div>
+
+                <div className='mb-6'>
+                  <div className='bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 mb-4'>
+                    <div className='flex items-center space-x-2 mb-2'>
+                      <svg
+                        className='w-5 h-5 text-red-600 dark:text-red-400'
+                        fill='none'
+                        stroke='currentColor'
+                        viewBox='0 0 24 24'
+                      >
+                        <path
+                          strokeLinecap='round'
+                          strokeLinejoin='round'
+                          strokeWidth={2}
+                          d='M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z'
+                        />
+                      </svg>
+                      <span className='text-sm font-medium text-red-800 dark:text-red-300'>
+                        危险操作警告
+                      </span>
+                    </div>
+                    <p className='text-sm text-red-700 dark:text-red-400'>
+                      删除用户 <strong>{deletingUser}</strong>{' '}
+                      将同时删除其搜索历史、播放记录和收藏夹，此操作不可恢复！
+                    </p>
+                  </div>
+
+                  {/* 操作按钮 */}
+                  <div className='flex justify-end space-x-3'>
+                    <button
+                      onClick={() => {
+                        setShowDeleteUserModal(false);
+                        setDeletingUser(null);
+                      }}
+                      className={`px-6 py-2.5 text-sm font-medium ${buttonStyles.secondary}`}
+                    >
+                      取消
+                    </button>
+                    <button
+                      onClick={handleConfirmDeleteUser}
+                      className={`px-6 py-2.5 text-sm font-medium ${buttonStyles.danger}`}
+                    >
+                      确认删除
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>,
+          document.body
+        )}
+
+      {/* TVBox Token 管理弹窗 */}
+      {showTVBoxTokenModal &&
+        tvboxTokenUser &&
+        createPortal(
+          <TVBoxTokenModal
+            username={tvboxTokenUser.username}
+            tvboxToken={tvboxTokenUser.tvboxToken}
+            tvboxEnabledSources={selectedTVBoxSources}
+            allSources={(config?.SourceConfig || [])
+              .filter((s) => !s.disabled)
+              .map((s) => ({ key: s.key, name: s.name }))}
+            onClose={() => {
+              setShowTVBoxTokenModal(false);
+              setTVBoxTokenUser(null);
+              setSelectedTVBoxSources([]);
+            }}
+            onUpdate={refreshConfig}
+          />,
+          document.body
+        )}
+
+      {/* 批量设置用户组弹窗 */}
+      {showBatchUserGroupModal &&
+        createPortal(
+          <div
+            className='fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4'
+            onClick={() => {
+              setShowBatchUserGroupModal(false);
+              setSelectedUserGroup('');
+            }}
+          >
+            <div
+              className='bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-2xl w-full'
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className='p-6'>
+                <div className='flex items-center justify-between mb-6'>
+                  <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
+                    批量设置用户组
+                  </h3>
+                  <button
+                    onClick={() => {
+                      setShowBatchUserGroupModal(false);
+                      setSelectedUserGroup('');
+                    }}
+                    className='text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors'
+                  >
+                    <svg
+                      className='w-6 h-6'
+                      fill='none'
+                      stroke='currentColor'
+                      viewBox='0 0 24 24'
+                    >
+                      <path
+                        strokeLinecap='round'
+                        strokeLinejoin='round'
+                        strokeWidth={2}
+                        d='M6 18L18 6M6 6l12 12'
+                      />
+                    </svg>
+                  </button>
+                </div>
+
+                <div className='mb-6'>
+                  <div className='bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4 mb-4'>
+                    <div className='flex items-center space-x-2 mb-2'>
+                      <svg
+                        className='w-5 h-5 text-blue-600 dark:text-blue-400'
+                        fill='none'
+                        stroke='currentColor'
+                        viewBox='0 0 24 24'
+                      >
+                        <path
+                          strokeLinecap='round'
+                          strokeLinejoin='round'
+                          strokeWidth={2}
+                          d='M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z'
+                        />
+                      </svg>
+                      <span className='text-sm font-medium text-blue-800 dark:text-blue-300'>
+                        批量操作说明
+                      </span>
+                    </div>
+                    <p className='text-sm text-blue-700 dark:text-blue-400'>
+                      将为选中的 <strong>{selectedUsers.size} 个用户</strong>{' '}
+                      设置用户组，选择"无用户组"为无限制
+                    </p>
+                  </div>
+
+                  <div>
+                    <label className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'>
+                      选择用户组：
+                    </label>
+                    <select
+                      onChange={(e) => setSelectedUserGroup(e.target.value)}
+                      className='w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors'
+                      value={selectedUserGroup}
+                    >
+                      <option value=''>无用户组（无限制）</option>
+                      {userGroups.map((group) => (
+                        <option key={group.name} value={group.name}>
+                          {group.name}{' '}
+                          {group.enabledApis && group.enabledApis.length > 0
+                            ? `(${group.enabledApis.length} 个源)`
+                            : ''}
+                        </option>
+                      ))}
+                    </select>
+                    <p className='mt-2 text-xs text-gray-500 dark:text-gray-400'>
+                      选择"无用户组"为无限制，选择特定用户组将限制用户只能访问该用户组允许的采集源
+                    </p>
+                  </div>
+                </div>
+
+                {/* 操作按钮 */}
+                <div className='flex justify-end space-x-3'>
+                  <button
+                    onClick={() => {
+                      setShowBatchUserGroupModal(false);
+                      setSelectedUserGroup('');
+                    }}
+                    className={`px-6 py-2.5 text-sm font-medium ${buttonStyles.secondary}`}
+                  >
+                    取消
+                  </button>
+                  <button
+                    onClick={() => handleBatchSetUserGroup(selectedUserGroup)}
+                    disabled={isLoading('batchSetUserGroup')}
+                    className={`px-6 py-2.5 text-sm font-medium ${
+                      isLoading('batchSetUserGroup')
+                        ? buttonStyles.disabled
+                        : buttonStyles.primary
+                    }`}
+                  >
+                    {isLoading('batchSetUserGroup') ? '设置中...' : '确认设置'}
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>,
+          document.body
+        )}
 
       {/* 通用弹窗组件 */}
       <AlertModal
@@ -2540,11 +3158,9 @@ const UserConfig = ({ config, role, refreshConfig }: UserConfigProps) => {
         timer={alertModal.timer}
         showConfirm={alertModal.showConfirm}
       />
-
-
     </div>
   );
-}
+};
 
 // 视频源配置组件
 const VideoSourceConfig = ({
@@ -2569,7 +3185,9 @@ const VideoSourceConfig = ({
   });
 
   // 批量操作相关状态
-  const [selectedSources, setSelectedSources] = useState<Set<string>>(new Set());
+  const [selectedSources, setSelectedSources] = useState<Set<string>>(
+    new Set()
+  );
 
   // 使用 useMemo 计算全选状态，避免每次渲染都重新计算
   const selectAll = useMemo(() => {
@@ -2607,21 +3225,23 @@ const VideoSourceConfig = ({
     isOpen: false,
     title: '',
     message: '',
-    onConfirm: () => { },
-    onCancel: () => { }
+    onConfirm: () => {},
+    onCancel: () => {},
   });
 
   // 有效性检测相关状态
   const [showValidationModal, setShowValidationModal] = useState(false);
   const [searchKeyword, setSearchKeyword] = useState('');
   const [isValidating, setIsValidating] = useState(false);
-  const [validationResults, setValidationResults] = useState<Array<{
-    key: string;
-    name: string;
-    status: 'valid' | 'no_results' | 'invalid' | 'validating';
-    message: string;
-    resultCount: number;
-  }>>([]);
+  const [validationResults, setValidationResults] = useState<
+    Array<{
+      key: string;
+      name: string;
+      status: 'valid' | 'no_results' | 'invalid' | 'validating';
+      message: string;
+      resultCount: number;
+    }>
+  >([]);
 
   // dnd-kit 传感器
   const sensors = useSensors(
@@ -2675,19 +3295,25 @@ const VideoSourceConfig = ({
     const target = sources.find((s) => s.key === key);
     if (!target) return;
     const action = target.disabled ? 'enable' : 'disable';
-    withLoading(`toggleSource_${key}`, () => callSourceApi({ action, key })).catch(() => {
+    withLoading(`toggleSource_${key}`, () =>
+      callSourceApi({ action, key })
+    ).catch(() => {
       console.error('操作失败', action, key);
     });
   };
 
   const handleDelete = (key: string) => {
-    withLoading(`deleteSource_${key}`, () => callSourceApi({ action: 'delete', key })).catch(() => {
+    withLoading(`deleteSource_${key}`, () =>
+      callSourceApi({ action: 'delete', key })
+    ).catch(() => {
       console.error('操作失败', 'delete', key);
     });
   };
 
   const handleToggleAdult = (key: string, is_adult: boolean) => {
-    withLoading(`toggleAdult_${key}`, () => callSourceApi({ action: 'update_adult', key, is_adult })).catch(() => {
+    withLoading(`toggleAdult_${key}`, () =>
+      callSourceApi({ action: 'update_adult', key, is_adult })
+    ).catch(() => {
       console.error('操作失败', 'update_adult', key);
     });
   };
@@ -2697,7 +3323,7 @@ const VideoSourceConfig = ({
       showAlert({
         type: 'warning',
         title: '提示',
-        message: '请先选择要操作的视频源'
+        message: '请先选择要操作的视频源',
       });
       return;
     }
@@ -2706,12 +3332,16 @@ const VideoSourceConfig = ({
     const action = markAsAdult ? 'batch_mark_adult' : 'batch_unmark_adult';
 
     try {
-      await withLoading(`batchSource_${action}`, () => callSourceApi({ action, keys }));
+      await withLoading(`batchSource_${action}`, () =>
+        callSourceApi({ action, keys })
+      );
       showAlert({
         type: 'success',
         title: '操作成功',
-        message: `${markAsAdult ? '标记' : '取消标记'}成功！共处理 ${keys.length} 个视频源`,
-        timer: 2000
+        message: `${markAsAdult ? '标记' : '取消标记'}成功！共处理 ${
+          keys.length
+        } 个视频源`,
+        timer: 2000,
       });
       setSelectedSources(new Set());
     } catch {
@@ -2719,7 +3349,7 @@ const VideoSourceConfig = ({
         type: 'error',
         title: '操作失败',
         message: `${markAsAdult ? '标记' : '取消标记'}失败，请重试`,
-        showConfirm: true
+        showConfirm: true,
       });
     }
   };
@@ -2761,7 +3391,9 @@ const VideoSourceConfig = ({
 
   const handleSaveOrder = () => {
     const order = sources.map((s) => s.key);
-    withLoading('saveSourceOrder', () => callSourceApi({ action: 'sort', order }))
+    withLoading('saveSourceOrder', () =>
+      callSourceApi({ action: 'sort', order })
+    )
       .then(() => {
         setOrderChanged(false);
       })
@@ -2773,7 +3405,11 @@ const VideoSourceConfig = ({
   // 有效性检测函数
   const handleValidateSources = async () => {
     if (!searchKeyword.trim()) {
-      showAlert({ type: 'warning', title: '请输入搜索关键词', message: '搜索关键词不能为空' });
+      showAlert({
+        type: 'warning',
+        title: '请输入搜索关键词',
+        message: '搜索关键词不能为空',
+      });
       return;
     }
 
@@ -2783,18 +3419,22 @@ const VideoSourceConfig = ({
       setShowValidationModal(false); // 立即关闭弹窗
 
       // 初始化所有视频源为检测中状态
-      const initialResults = sources.map(source => ({
+      const initialResults = sources.map((source) => ({
         key: source.key,
         name: source.name,
         status: 'validating' as const,
         message: '检测中...',
-        resultCount: 0
+        resultCount: 0,
       }));
       setValidationResults(initialResults);
 
       try {
         // 使用EventSource接收流式数据
-        const eventSource = new EventSource(`/api/admin/source/validate?q=${encodeURIComponent(searchKeyword.trim())}`);
+        const eventSource = new EventSource(
+          `/api/admin/source/validate?q=${encodeURIComponent(
+            searchKeyword.trim()
+          )}`
+        );
 
         eventSource.onmessage = (event) => {
           try {
@@ -2808,32 +3448,53 @@ const VideoSourceConfig = ({
               case 'source_result':
               case 'source_error':
                 // 更新验证结果
-                setValidationResults(prev => {
-                  const existing = prev.find(r => r.key === data.source);
+                setValidationResults((prev) => {
+                  const existing = prev.find((r) => r.key === data.source);
                   if (existing) {
-                    return prev.map(r => r.key === data.source ? {
-                      key: data.source,
-                      name: sources.find(s => s.key === data.source)?.name || data.source,
-                      status: data.status,
-                      message: data.status === 'valid' ? '搜索正常' :
-                        data.status === 'no_results' ? '无法搜索到结果' : '连接失败',
-                      resultCount: data.status === 'valid' ? 1 : 0
-                    } : r);
+                    return prev.map((r) =>
+                      r.key === data.source
+                        ? {
+                            key: data.source,
+                            name:
+                              sources.find((s) => s.key === data.source)
+                                ?.name || data.source,
+                            status: data.status,
+                            message:
+                              data.status === 'valid'
+                                ? '搜索正常'
+                                : data.status === 'no_results'
+                                ? '无法搜索到结果'
+                                : '连接失败',
+                            resultCount: data.status === 'valid' ? 1 : 0,
+                          }
+                        : r
+                    );
                   } else {
-                    return [...prev, {
-                      key: data.source,
-                      name: sources.find(s => s.key === data.source)?.name || data.source,
-                      status: data.status,
-                      message: data.status === 'valid' ? '搜索正常' :
-                        data.status === 'no_results' ? '无法搜索到结果' : '连接失败',
-                      resultCount: data.status === 'valid' ? 1 : 0
-                    }];
+                    return [
+                      ...prev,
+                      {
+                        key: data.source,
+                        name:
+                          sources.find((s) => s.key === data.source)?.name ||
+                          data.source,
+                        status: data.status,
+                        message:
+                          data.status === 'valid'
+                            ? '搜索正常'
+                            : data.status === 'no_results'
+                            ? '无法搜索到结果'
+                            : '连接失败',
+                        resultCount: data.status === 'valid' ? 1 : 0,
+                      },
+                    ];
                   }
                 });
                 break;
 
               case 'complete':
-                console.log(`检测完成，共检测 ${data.completedSources} 个视频源`);
+                console.log(
+                  `检测完成，共检测 ${data.completedSources} 个视频源`
+                );
                 eventSource.close();
                 setIsValidating(false);
                 break;
@@ -2847,7 +3508,11 @@ const VideoSourceConfig = ({
           console.error('EventSource错误:', error);
           eventSource.close();
           setIsValidating(false);
-          showAlert({ type: 'error', title: '验证失败', message: '连接错误，请重试' });
+          showAlert({
+            type: 'error',
+            title: '验证失败',
+            message: '连接错误，请重试',
+          });
         };
 
         // 设置超时，防止长时间等待
@@ -2855,13 +3520,20 @@ const VideoSourceConfig = ({
           if (eventSource.readyState === EventSource.OPEN) {
             eventSource.close();
             setIsValidating(false);
-            showAlert({ type: 'warning', title: '验证超时', message: '检测超时，请重试' });
+            showAlert({
+              type: 'warning',
+              title: '验证超时',
+              message: '检测超时，请重试',
+            });
           }
         }, 60000); // 60秒超时
-
       } catch (error) {
         setIsValidating(false);
-        showAlert({ type: 'error', title: '验证失败', message: error instanceof Error ? error.message : '未知错误' });
+        showAlert({
+          type: 'error',
+          title: '验证失败',
+          message: error instanceof Error ? error.message : '未知错误',
+        });
         throw error;
       }
     });
@@ -2869,37 +3541,41 @@ const VideoSourceConfig = ({
 
   // 获取有效性状态显示
   const getValidationStatus = (sourceKey: string) => {
-    const result = validationResults.find(r => r.key === sourceKey);
+    const result = validationResults.find((r) => r.key === sourceKey);
     if (!result) return null;
 
     switch (result.status) {
       case 'validating':
         return {
           text: '检测中',
-          className: 'bg-blue-100 dark:bg-blue-900/20 text-blue-800 dark:text-blue-300',
+          className:
+            'bg-blue-100 dark:bg-blue-900/20 text-blue-800 dark:text-blue-300',
           icon: '⟳',
-          message: result.message
+          message: result.message,
         };
       case 'valid':
         return {
           text: '有效',
-          className: 'bg-green-100 dark:bg-green-900/20 text-green-800 dark:text-green-300',
+          className:
+            'bg-green-100 dark:bg-green-900/20 text-green-800 dark:text-green-300',
           icon: '✓',
-          message: result.message
+          message: result.message,
         };
       case 'no_results':
         return {
           text: '无法搜索',
-          className: 'bg-yellow-100 dark:bg-yellow-900/20 text-yellow-800 dark:text-yellow-300',
+          className:
+            'bg-yellow-100 dark:bg-yellow-900/20 text-yellow-800 dark:text-yellow-300',
           icon: '⚠',
-          message: result.message
+          message: result.message,
         };
       case 'invalid':
         return {
           text: '无效',
-          className: 'bg-red-100 dark:bg-red-900/20 text-red-800 dark:text-red-300',
+          className:
+            'bg-red-100 dark:bg-red-900/20 text-red-800 dark:text-red-300',
           icon: '✗',
-          message: result.message
+          message: result.message,
         };
       default:
         return null;
@@ -2958,10 +3634,11 @@ const VideoSourceConfig = ({
         </td>
         <td className='px-6 py-4 whitespace-nowrap max-w-[1rem]'>
           <span
-            className={`px-2 py-1 text-xs rounded-full ${!source.disabled
-              ? 'bg-green-100 dark:bg-green-900/20 text-green-800 dark:text-green-300'
-              : 'bg-red-100 dark:bg-red-900/20 text-red-800 dark:text-red-300'
-              }`}
+            className={`px-2 py-1 text-xs rounded-full ${
+              !source.disabled
+                ? 'bg-green-100 dark:bg-green-900/20 text-green-800 dark:text-green-300'
+                : 'bg-red-100 dark:bg-red-900/20 text-red-800 dark:text-red-300'
+            }`}
           >
             {!source.disabled ? '启用中' : '已禁用'}
           </span>
@@ -2970,16 +3647,29 @@ const VideoSourceConfig = ({
           <button
             onClick={() => handleToggleAdult(source.key, !source.is_adult)}
             disabled={isLoading(`toggleAdult_${source.key}`)}
-            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 ${source.is_adult
-              ? 'bg-gradient-to-r from-red-600 to-pink-600 focus:ring-red-500'
-              : 'bg-gray-200 dark:bg-gray-700 focus:ring-gray-500'
-            } ${isLoading(`toggleAdult_${source.key}`) ? 'opacity-50 cursor-not-allowed' : ''}`}
-            title={source.is_adult ? '点击取消成人资源标记' : '点击标记为成人资源'}
+            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 ${
+              source.is_adult
+                ? 'bg-gradient-to-r from-red-600 to-pink-600 focus:ring-red-500'
+                : 'bg-gray-200 dark:bg-gray-700 focus:ring-gray-500'
+            } ${
+              isLoading(`toggleAdult_${source.key}`)
+                ? 'opacity-50 cursor-not-allowed'
+                : ''
+            }`}
+            title={
+              source.is_adult ? '点击取消成人资源标记' : '点击标记为成人资源'
+            }
           >
-            <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${source.is_adult ? 'translate-x-6' : 'translate-x-1'}`} />
+            <span
+              className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                source.is_adult ? 'translate-x-6' : 'translate-x-1'
+              }`}
+            />
           </button>
           {source.is_adult && (
-            <span className='ml-2 text-xs text-red-600 dark:text-red-400'>🔞</span>
+            <span className='ml-2 text-xs text-red-600 dark:text-red-400'>
+              🔞
+            </span>
           )}
         </td>
         <td className='px-6 py-4 whitespace-nowrap max-w-[1rem]'>
@@ -2993,7 +3683,10 @@ const VideoSourceConfig = ({
               );
             }
             return (
-              <span className={`px-2 py-1 text-xs rounded-full ${status.className}`} title={status.message}>
+              <span
+                className={`px-2 py-1 text-xs rounded-full ${status.className}`}
+                title={status.message}
+              >
                 {status.icon} {status.text}
               </span>
             );
@@ -3003,10 +3696,15 @@ const VideoSourceConfig = ({
           <button
             onClick={() => handleToggleEnable(source.key)}
             disabled={isLoading(`toggleSource_${source.key}`)}
-            className={`inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium ${!source.disabled
-              ? buttonStyles.roundedDanger
-              : buttonStyles.roundedSuccess
-              } transition-colors ${isLoading(`toggleSource_${source.key}`) ? 'opacity-50 cursor-not-allowed' : ''}`}
+            className={`inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium ${
+              !source.disabled
+                ? buttonStyles.roundedDanger
+                : buttonStyles.roundedSuccess
+            } transition-colors ${
+              isLoading(`toggleSource_${source.key}`)
+                ? 'opacity-50 cursor-not-allowed'
+                : ''
+            }`}
           >
             {!source.disabled ? '禁用' : '启用'}
           </button>
@@ -3014,7 +3712,11 @@ const VideoSourceConfig = ({
             <button
               onClick={() => handleDelete(source.key)}
               disabled={isLoading(`deleteSource_${source.key}`)}
-              className={`${buttonStyles.roundedSecondary} ${isLoading(`deleteSource_${source.key}`) ? 'opacity-50 cursor-not-allowed' : ''}`}
+              className={`${buttonStyles.roundedSecondary} ${
+                isLoading(`deleteSource_${source.key}`)
+                  ? 'opacity-50 cursor-not-allowed'
+                  : ''
+              }`}
             >
               删除
             </button>
@@ -3025,18 +3727,21 @@ const VideoSourceConfig = ({
   };
 
   // 全选/取消全选
-  const handleSelectAll = useCallback((checked: boolean) => {
-    if (checked) {
-      const allKeys = sources.map(s => s.key);
-      setSelectedSources(new Set(allKeys));
-    } else {
-      setSelectedSources(new Set());
-    }
-  }, [sources]);
+  const handleSelectAll = useCallback(
+    (checked: boolean) => {
+      if (checked) {
+        const allKeys = sources.map((s) => s.key);
+        setSelectedSources(new Set(allKeys));
+      } else {
+        setSelectedSources(new Set());
+      }
+    },
+    [sources]
+  );
 
   // 单个选择
   const handleSelectSource = useCallback((key: string, checked: boolean) => {
-    setSelectedSources(prev => {
+    setSelectedSources((prev) => {
       const newSelected = new Set(prev);
       if (checked) {
         newSelected.add(key);
@@ -3048,9 +3753,15 @@ const VideoSourceConfig = ({
   }, []);
 
   // 批量操作
-  const handleBatchOperation = async (action: 'batch_enable' | 'batch_disable' | 'batch_delete') => {
+  const handleBatchOperation = async (
+    action: 'batch_enable' | 'batch_disable' | 'batch_delete'
+  ) => {
     if (selectedSources.size === 0) {
-      showAlert({ type: 'warning', title: '请先选择要操作的视频源', message: '请选择至少一个视频源' });
+      showAlert({
+        type: 'warning',
+        title: '请先选择要操作的视频源',
+        message: '请选择至少一个视频源',
+      });
       return;
     }
 
@@ -3080,18 +3791,41 @@ const VideoSourceConfig = ({
       message: confirmMessage,
       onConfirm: async () => {
         try {
-          await withLoading(`batchSource_${action}`, () => callSourceApi({ action, keys }));
-          showAlert({ type: 'success', title: `${actionName}成功`, message: `${actionName}了 ${keys.length} 个视频源`, timer: 2000 });
+          await withLoading(`batchSource_${action}`, () =>
+            callSourceApi({ action, keys })
+          );
+          showAlert({
+            type: 'success',
+            title: `${actionName}成功`,
+            message: `${actionName}了 ${keys.length} 个视频源`,
+            timer: 2000,
+          });
           // 重置选择状态
           setSelectedSources(new Set());
         } catch (err) {
-          showAlert({ type: 'error', title: `${actionName}失败`, message: err instanceof Error ? err.message : '操作失败' });
+          showAlert({
+            type: 'error',
+            title: `${actionName}失败`,
+            message: err instanceof Error ? err.message : '操作失败',
+          });
         }
-        setConfirmModal({ isOpen: false, title: '', message: '', onConfirm: () => { }, onCancel: () => { } });
+        setConfirmModal({
+          isOpen: false,
+          title: '',
+          message: '',
+          onConfirm: () => {},
+          onCancel: () => {},
+        });
       },
       onCancel: () => {
-        setConfirmModal({ isOpen: false, title: '', message: '', onConfirm: () => { }, onCancel: () => { } });
-      }
+        setConfirmModal({
+          isOpen: false,
+          title: '',
+          message: '',
+          onConfirm: () => {},
+          onCancel: () => {},
+        });
+      },
     });
   };
 
@@ -3165,7 +3899,9 @@ const VideoSourceConfig = ({
       showAlert({
         type: 'success',
         title: '导出成功',
-        message: `已导出 ${sourcesToExport.length} 个视频源到 ${filename}（${exportFormat === 'array' ? '数组格式' : '配置文件格式'}）`,
+        message: `已导出 ${sourcesToExport.length} 个视频源到 ${filename}（${
+          exportFormat === 'array' ? '数组格式' : '配置文件格式'
+        }）`,
         timer: 3000,
       });
 
@@ -3302,7 +4038,9 @@ const VideoSourceConfig = ({
       <div className='flex justify-center items-center py-8'>
         <div className='flex items-center gap-3 px-6 py-3 bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20 rounded-xl border border-blue-200/50 dark:border-blue-700/50 shadow-md'>
           <div className='animate-spin rounded-full h-5 w-5 border-2 border-blue-300 border-t-blue-600 dark:border-blue-700 dark:border-t-blue-400'></div>
-          <span className='text-sm font-medium text-gray-700 dark:text-gray-300'>加载配置中...</span>
+          <span className='text-sm font-medium text-gray-700 dark:text-gray-300'>
+            加载配置中...
+          </span>
         </div>
       </div>
     );
@@ -3322,44 +4060,76 @@ const VideoSourceConfig = ({
               <div className='flex flex-wrap items-center gap-3 order-2 sm:order-1'>
                 <span className='text-sm text-gray-600 dark:text-gray-400'>
                   <span className='sm:hidden'>已选 {selectedSources.size}</span>
-                  <span className='hidden sm:inline'>已选择 {selectedSources.size} 个视频源</span>
+                  <span className='hidden sm:inline'>
+                    已选择 {selectedSources.size} 个视频源
+                  </span>
                 </span>
                 <button
                   onClick={() => handleBatchOperation('batch_enable')}
                   disabled={isLoading('batchSource_batch_enable')}
-                  className={`px-3 py-1 text-sm ${isLoading('batchSource_batch_enable') ? buttonStyles.disabled : buttonStyles.success}`}
+                  className={`px-3 py-1 text-sm ${
+                    isLoading('batchSource_batch_enable')
+                      ? buttonStyles.disabled
+                      : buttonStyles.success
+                  }`}
                 >
-                  {isLoading('batchSource_batch_enable') ? '启用中...' : '批量启用'}
+                  {isLoading('batchSource_batch_enable')
+                    ? '启用中...'
+                    : '批量启用'}
                 </button>
                 <button
                   onClick={() => handleBatchOperation('batch_disable')}
                   disabled={isLoading('batchSource_batch_disable')}
-                  className={`px-3 py-1 text-sm ${isLoading('batchSource_batch_disable') ? buttonStyles.disabled : buttonStyles.warning}`}
+                  className={`px-3 py-1 text-sm ${
+                    isLoading('batchSource_batch_disable')
+                      ? buttonStyles.disabled
+                      : buttonStyles.warning
+                  }`}
                 >
-                  {isLoading('batchSource_batch_disable') ? '禁用中...' : '批量禁用'}
+                  {isLoading('batchSource_batch_disable')
+                    ? '禁用中...'
+                    : '批量禁用'}
                 </button>
                 <button
                   onClick={() => handleBatchOperation('batch_delete')}
                   disabled={isLoading('batchSource_batch_delete')}
-                  className={`px-3 py-1 text-sm ${isLoading('batchSource_batch_delete') ? buttonStyles.disabled : buttonStyles.danger}`}
+                  className={`px-3 py-1 text-sm ${
+                    isLoading('batchSource_batch_delete')
+                      ? buttonStyles.disabled
+                      : buttonStyles.danger
+                  }`}
                 >
-                  {isLoading('batchSource_batch_delete') ? '删除中...' : '批量删除'}
+                  {isLoading('batchSource_batch_delete')
+                    ? '删除中...'
+                    : '批量删除'}
                 </button>
                 <button
                   onClick={() => handleBatchMarkAdult(true)}
                   disabled={isLoading('batchSource_batch_mark_adult')}
-                  className={`px-3 py-1 text-sm ${isLoading('batchSource_batch_mark_adult') ? buttonStyles.disabled : 'bg-gradient-to-r from-red-600 to-pink-600 hover:from-red-700 hover:to-pink-700 text-white rounded-lg transition-colors'}`}
+                  className={`px-3 py-1 text-sm ${
+                    isLoading('batchSource_batch_mark_adult')
+                      ? buttonStyles.disabled
+                      : 'bg-gradient-to-r from-red-600 to-pink-600 hover:from-red-700 hover:to-pink-700 text-white rounded-lg transition-colors'
+                  }`}
                   title='将选中的视频源标记为成人资源'
                 >
-                  {isLoading('batchSource_batch_mark_adult') ? '标记中...' : '标记成人'}
+                  {isLoading('batchSource_batch_mark_adult')
+                    ? '标记中...'
+                    : '标记成人'}
                 </button>
                 <button
                   onClick={() => handleBatchMarkAdult(false)}
                   disabled={isLoading('batchSource_batch_unmark_adult')}
-                  className={`px-3 py-1 text-sm ${isLoading('batchSource_batch_unmark_adult') ? buttonStyles.disabled : buttonStyles.secondary}`}
+                  className={`px-3 py-1 text-sm ${
+                    isLoading('batchSource_batch_unmark_adult')
+                      ? buttonStyles.disabled
+                      : buttonStyles.secondary
+                  }`}
                   title='取消选中视频源的成人资源标记'
                 >
-                  {isLoading('batchSource_batch_unmark_adult') ? '取消中...' : '取消标记'}
+                  {isLoading('batchSource_batch_unmark_adult')
+                    ? '取消中...'
+                    : '取消标记'}
                 </button>
               </div>
               <div className='hidden sm:block w-px h-6 bg-gray-300 dark:bg-gray-600 order-2'></div>
@@ -3367,7 +4137,9 @@ const VideoSourceConfig = ({
           )}
           <div className='flex items-center gap-2 order-1 sm:order-2'>
             <button
-              onClick={() => setImportExportModal({ isOpen: true, mode: 'import' })}
+              onClick={() =>
+                setImportExportModal({ isOpen: true, mode: 'import' })
+              }
               className='px-3 py-1 text-sm rounded-lg transition-colors flex items-center space-x-1 bg-gradient-to-r from-blue-600 to-cyan-500 hover:from-blue-700 hover:to-cyan-600 text-white'
               title='从 JSON 文件导入视频源'
             >
@@ -3376,7 +4148,9 @@ const VideoSourceConfig = ({
               <span className='sm:hidden'>导入</span>
             </button>
             <button
-              onClick={() => setImportExportModal({ isOpen: true, mode: 'export' })}
+              onClick={() =>
+                setImportExportModal({ isOpen: true, mode: 'export' })
+              }
               className='px-3 py-1 text-sm rounded-lg transition-colors flex items-center space-x-1 bg-gradient-to-r from-green-600 to-emerald-500 hover:from-green-700 hover:to-emerald-600 text-white'
               title={
                 selectedSources.size > 0
@@ -3395,10 +4169,9 @@ const VideoSourceConfig = ({
             <button
               onClick={() => setShowValidationModal(true)}
               disabled={isValidating}
-              className={`px-3 py-1 text-sm rounded-lg transition-colors flex items-center space-x-1 ${isValidating
-                ? buttonStyles.disabled
-                : buttonStyles.primary
-                }`}
+              className={`px-3 py-1 text-sm rounded-lg transition-colors flex items-center space-x-1 ${
+                isValidating ? buttonStyles.disabled : buttonStyles.primary
+              }`}
             >
               {isValidating ? (
                 <>
@@ -3411,7 +4184,9 @@ const VideoSourceConfig = ({
             </button>
             <button
               onClick={() => setShowAddForm(!showAddForm)}
-              className={showAddForm ? buttonStyles.secondary : buttonStyles.success}
+              className={
+                showAddForm ? buttonStyles.secondary : buttonStyles.success
+              }
             >
               {showAddForm ? '取消' : '添加视频源'}
             </button>
@@ -3468,7 +4243,10 @@ const VideoSourceConfig = ({
                 type='checkbox'
                 checked={newSource.is_adult || false}
                 onChange={(e) =>
-                  setNewSource((prev) => ({ ...prev, is_adult: e.target.checked }))
+                  setNewSource((prev) => ({
+                    ...prev,
+                    is_adult: e.target.checked,
+                  }))
                 }
                 className='w-4 h-4 text-red-600 bg-gray-100 border-gray-300 rounded focus:ring-red-500 dark:focus:ring-red-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
               />
@@ -3485,8 +4263,20 @@ const VideoSourceConfig = ({
           <div className='flex justify-end'>
             <button
               onClick={handleAddSource}
-              disabled={!newSource.name || !newSource.key || !newSource.api || isLoading('addSource')}
-              className={`w-full sm:w-auto px-4 py-2 ${!newSource.name || !newSource.key || !newSource.api || isLoading('addSource') ? buttonStyles.disabled : buttonStyles.success}`}
+              disabled={
+                !newSource.name ||
+                !newSource.key ||
+                !newSource.api ||
+                isLoading('addSource')
+              }
+              className={`w-full sm:w-auto px-4 py-2 ${
+                !newSource.name ||
+                !newSource.key ||
+                !newSource.api ||
+                isLoading('addSource')
+                  ? buttonStyles.disabled
+                  : buttonStyles.success
+              }`}
             >
               {isLoading('addSource') ? '添加中...' : '添加'}
             </button>
@@ -3494,10 +4284,11 @@ const VideoSourceConfig = ({
         </div>
       )}
 
-
-
       {/* 视频源表格 */}
-      <div className='border border-gray-200 dark:border-gray-700 rounded-lg max-h-[28rem] overflow-y-auto overflow-x-auto relative' data-table="source-list">
+      <div
+        className='border border-gray-200 dark:border-gray-700 rounded-lg max-h-[28rem] overflow-y-auto overflow-x-auto relative'
+        data-table='source-list'
+      >
         <table className='min-w-full divide-y divide-gray-200 dark:divide-gray-700'>
           <thead className='bg-gray-50 dark:bg-gray-900 sticky top-0 z-10'>
             <tr>
@@ -3563,7 +4354,11 @@ const VideoSourceConfig = ({
           <button
             onClick={handleSaveOrder}
             disabled={isLoading('saveSourceOrder')}
-            className={`px-3 py-1.5 text-sm ${isLoading('saveSourceOrder') ? buttonStyles.disabled : buttonStyles.primary}`}
+            className={`px-3 py-1.5 text-sm ${
+              isLoading('saveSourceOrder')
+                ? buttonStyles.disabled
+                : buttonStyles.primary
+            }`}
           >
             {isLoading('saveSourceOrder') ? '保存中...' : '保存排序'}
           </button>
@@ -3571,44 +4366,57 @@ const VideoSourceConfig = ({
       )}
 
       {/* 有效性检测弹窗 */}
-      {showValidationModal && createPortal(
-        <div className='fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50' onClick={() => setShowValidationModal(false)}>
-          <div className='bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-w-md mx-4' onClick={(e) => e.stopPropagation()}>
-            <h3 className='text-lg font-medium text-gray-900 dark:text-gray-100 mb-4'>
-              视频源有效性检测
-            </h3>
-            <p className='text-sm text-gray-600 dark:text-gray-400 mb-4'>
-              请输入检测用的搜索关键词
-            </p>
-            <div className='space-y-4'>
-              <input
-                type='text'
-                placeholder='请输入搜索关键词'
-                value={searchKeyword}
-                onChange={(e) => setSearchKeyword(e.target.value)}
-                className='w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100'
-                onKeyPress={(e) => e.key === 'Enter' && handleValidateSources()}
-              />
-              <div className='flex justify-end space-x-3'>
-                <button
-                  onClick={() => setShowValidationModal(false)}
-                  className='px-4 py-2 text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 transition-colors'
-                >
-                  取消
-                </button>
-                <button
-                  onClick={handleValidateSources}
-                  disabled={!searchKeyword.trim()}
-                  className={`px-4 py-2 ${!searchKeyword.trim() ? buttonStyles.disabled : buttonStyles.primary}`}
-                >
-                  开始检测
-                </button>
+      {showValidationModal &&
+        createPortal(
+          <div
+            className='fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50'
+            onClick={() => setShowValidationModal(false)}
+          >
+            <div
+              className='bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-w-md mx-4'
+              onClick={(e) => e.stopPropagation()}
+            >
+              <h3 className='text-lg font-medium text-gray-900 dark:text-gray-100 mb-4'>
+                视频源有效性检测
+              </h3>
+              <p className='text-sm text-gray-600 dark:text-gray-400 mb-4'>
+                请输入检测用的搜索关键词
+              </p>
+              <div className='space-y-4'>
+                <input
+                  type='text'
+                  placeholder='请输入搜索关键词'
+                  value={searchKeyword}
+                  onChange={(e) => setSearchKeyword(e.target.value)}
+                  className='w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100'
+                  onKeyPress={(e) =>
+                    e.key === 'Enter' && handleValidateSources()
+                  }
+                />
+                <div className='flex justify-end space-x-3'>
+                  <button
+                    onClick={() => setShowValidationModal(false)}
+                    className='px-4 py-2 text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 transition-colors'
+                  >
+                    取消
+                  </button>
+                  <button
+                    onClick={handleValidateSources}
+                    disabled={!searchKeyword.trim()}
+                    className={`px-4 py-2 ${
+                      !searchKeyword.trim()
+                        ? buttonStyles.disabled
+                        : buttonStyles.primary
+                    }`}
+                  >
+                    开始检测
+                  </button>
+                </div>
               </div>
             </div>
-          </div>
-        </div>,
-        document.body
-      )}
+          </div>,
+          document.body
+        )}
 
       {/* 通用弹窗组件 */}
       <AlertModal
@@ -3622,51 +4430,82 @@ const VideoSourceConfig = ({
       />
 
       {/* 批量操作确认弹窗 */}
-      {confirmModal.isOpen && createPortal(
-        <div className='fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4' onClick={confirmModal.onCancel}>
-          <div className='bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-md w-full' onClick={(e) => e.stopPropagation()}>
-            <div className='p-6'>
-              <div className='flex items-center justify-between mb-4'>
-                <h3 className='text-lg font-semibold text-gray-900 dark:text-gray-100'>
-                  {confirmModal.title}
-                </h3>
-                <button
-                  onClick={confirmModal.onCancel}
-                  className='text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors'
-                >
-                  <svg className='w-5 h-5' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                    <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M6 18L18 6M6 6l12 12' />
-                  </svg>
-                </button>
-              </div>
+      {confirmModal.isOpen &&
+        createPortal(
+          <div
+            className='fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4'
+            onClick={confirmModal.onCancel}
+          >
+            <div
+              className='bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-md w-full'
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className='p-6'>
+                <div className='flex items-center justify-between mb-4'>
+                  <h3 className='text-lg font-semibold text-gray-900 dark:text-gray-100'>
+                    {confirmModal.title}
+                  </h3>
+                  <button
+                    onClick={confirmModal.onCancel}
+                    className='text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors'
+                  >
+                    <svg
+                      className='w-5 h-5'
+                      fill='none'
+                      stroke='currentColor'
+                      viewBox='0 0 24 24'
+                    >
+                      <path
+                        strokeLinecap='round'
+                        strokeLinejoin='round'
+                        strokeWidth={2}
+                        d='M6 18L18 6M6 6l12 12'
+                      />
+                    </svg>
+                  </button>
+                </div>
 
-              <div className='mb-6'>
-                <p className='text-sm text-gray-600 dark:text-gray-400'>
-                  {confirmModal.message}
-                </p>
-              </div>
+                <div className='mb-6'>
+                  <p className='text-sm text-gray-600 dark:text-gray-400'>
+                    {confirmModal.message}
+                  </p>
+                </div>
 
-              {/* 操作按钮 */}
-              <div className='flex justify-end space-x-3'>
-                <button
-                  onClick={confirmModal.onCancel}
-                  className={`px-4 py-2 text-sm font-medium ${buttonStyles.secondary}`}
-                >
-                  取消
-                </button>
-                <button
-                  onClick={confirmModal.onConfirm}
-                  disabled={isLoading('batchSource_batch_enable') || isLoading('batchSource_batch_disable') || isLoading('batchSource_batch_delete')}
-                  className={`px-4 py-2 text-sm font-medium ${isLoading('batchSource_batch_enable') || isLoading('batchSource_batch_disable') || isLoading('batchSource_batch_delete') ? buttonStyles.disabled : buttonStyles.primary}`}
-                >
-                  {isLoading('batchSource_batch_enable') || isLoading('batchSource_batch_disable') || isLoading('batchSource_batch_delete') ? '操作中...' : '确认'}
-                </button>
+                {/* 操作按钮 */}
+                <div className='flex justify-end space-x-3'>
+                  <button
+                    onClick={confirmModal.onCancel}
+                    className={`px-4 py-2 text-sm font-medium ${buttonStyles.secondary}`}
+                  >
+                    取消
+                  </button>
+                  <button
+                    onClick={confirmModal.onConfirm}
+                    disabled={
+                      isLoading('batchSource_batch_enable') ||
+                      isLoading('batchSource_batch_disable') ||
+                      isLoading('batchSource_batch_delete')
+                    }
+                    className={`px-4 py-2 text-sm font-medium ${
+                      isLoading('batchSource_batch_enable') ||
+                      isLoading('batchSource_batch_disable') ||
+                      isLoading('batchSource_batch_delete')
+                        ? buttonStyles.disabled
+                        : buttonStyles.primary
+                    }`}
+                  >
+                    {isLoading('batchSource_batch_enable') ||
+                    isLoading('batchSource_batch_disable') ||
+                    isLoading('batchSource_batch_delete')
+                      ? '操作中...'
+                      : '确认'}
+                  </button>
+                </div>
               </div>
             </div>
-          </div>
-        </div>,
-        document.body
-      )}
+          </div>,
+          document.body
+        )}
 
       {/* 导入导出模态框 */}
       <ImportExportModal
@@ -3752,13 +4591,17 @@ const CategoryConfig = ({
     const target = categories.find((c) => c.query === query && c.type === type);
     if (!target) return;
     const action = target.disabled ? 'enable' : 'disable';
-    withLoading(`toggleCategory_${query}_${type}`, () => callCategoryApi({ action, query, type })).catch(() => {
+    withLoading(`toggleCategory_${query}_${type}`, () =>
+      callCategoryApi({ action, query, type })
+    ).catch(() => {
       console.error('操作失败', action, query, type);
     });
   };
 
   const handleDelete = (query: string, type: 'movie' | 'tv') => {
-    withLoading(`deleteCategory_${query}_${type}`, () => callCategoryApi({ action: 'delete', query, type })).catch(() => {
+    withLoading(`deleteCategory_${query}_${type}`, () =>
+      callCategoryApi({ action: 'delete', query, type })
+    ).catch(() => {
       console.error('操作失败', 'delete', query, type);
     });
   };
@@ -3800,7 +4643,9 @@ const CategoryConfig = ({
 
   const handleSaveOrder = () => {
     const order = categories.map((c) => `${c.query}:${c.type}`);
-    withLoading('saveCategoryOrder', () => callCategoryApi({ action: 'sort', order }))
+    withLoading('saveCategoryOrder', () =>
+      callCategoryApi({ action: 'sort', order })
+    )
       .then(() => {
         setOrderChanged(false);
       })
@@ -3826,7 +4671,7 @@ const CategoryConfig = ({
         className='hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors select-none'
       >
         <td
-          className="px-2 py-4 cursor-grab text-gray-400"
+          className='px-2 py-4 cursor-grab text-gray-400'
           style={{ touchAction: 'none' }}
           {...{ ...attributes, ...listeners }}
         >
@@ -3837,10 +4682,11 @@ const CategoryConfig = ({
         </td>
         <td className='px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100'>
           <span
-            className={`px-2 py-1 text-xs rounded-full ${category.type === 'movie'
-              ? 'bg-blue-100 dark:bg-blue-900/20 text-blue-800 dark:text-blue-300'
-              : 'bg-purple-100 dark:bg-purple-900/20 text-purple-800 dark:text-purple-300'
-              }`}
+            className={`px-2 py-1 text-xs rounded-full ${
+              category.type === 'movie'
+                ? 'bg-blue-100 dark:bg-blue-900/20 text-blue-800 dark:text-blue-300'
+                : 'bg-purple-100 dark:bg-purple-900/20 text-purple-800 dark:text-purple-300'
+            }`}
           >
             {category.type === 'movie' ? '电影' : '电视剧'}
           </span>
@@ -3853,32 +4699,44 @@ const CategoryConfig = ({
         </td>
         <td className='px-6 py-4 whitespace-nowrap max-w-[1rem]'>
           <span
-            className={`px-2 py-1 text-xs rounded-full ${!category.disabled
-              ? 'bg-green-100 dark:bg-green-900/20 text-green-800 dark:text-green-300'
-              : 'bg-red-100 dark:bg-red-900/20 text-red-800 dark:text-red-300'
-              }`}
+            className={`px-2 py-1 text-xs rounded-full ${
+              !category.disabled
+                ? 'bg-green-100 dark:bg-green-900/20 text-green-800 dark:text-green-300'
+                : 'bg-red-100 dark:bg-red-900/20 text-red-800 dark:text-red-300'
+            }`}
           >
             {!category.disabled ? '启用中' : '已禁用'}
           </span>
         </td>
         <td className='px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2'>
           <button
-            onClick={() =>
-              handleToggleEnable(category.query, category.type)
-            }
-            disabled={isLoading(`toggleCategory_${category.query}_${category.type}`)}
-            className={`inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium ${!category.disabled
-              ? buttonStyles.roundedDanger
-              : buttonStyles.roundedSuccess
-              } transition-colors ${isLoading(`toggleCategory_${category.query}_${category.type}`) ? 'opacity-50 cursor-not-allowed' : ''}`}
+            onClick={() => handleToggleEnable(category.query, category.type)}
+            disabled={isLoading(
+              `toggleCategory_${category.query}_${category.type}`
+            )}
+            className={`inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium ${
+              !category.disabled
+                ? buttonStyles.roundedDanger
+                : buttonStyles.roundedSuccess
+            } transition-colors ${
+              isLoading(`toggleCategory_${category.query}_${category.type}`)
+                ? 'opacity-50 cursor-not-allowed'
+                : ''
+            }`}
           >
             {!category.disabled ? '禁用' : '启用'}
           </button>
           {category.from !== 'config' && (
             <button
               onClick={() => handleDelete(category.query, category.type)}
-              disabled={isLoading(`deleteCategory_${category.query}_${category.type}`)}
-              className={`${buttonStyles.roundedSecondary} ${isLoading(`deleteCategory_${category.query}_${category.type}`) ? 'opacity-50 cursor-not-allowed' : ''}`}
+              disabled={isLoading(
+                `deleteCategory_${category.query}_${category.type}`
+              )}
+              className={`${buttonStyles.roundedSecondary} ${
+                isLoading(`deleteCategory_${category.query}_${category.type}`)
+                  ? 'opacity-50 cursor-not-allowed'
+                  : ''
+              }`}
             >
               删除
             </button>
@@ -3893,7 +4751,9 @@ const CategoryConfig = ({
       <div className='flex justify-center items-center py-8'>
         <div className='flex items-center gap-3 px-6 py-3 bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20 rounded-xl border border-blue-200/50 dark:border-blue-700/50 shadow-md'>
           <div className='animate-spin rounded-full h-5 w-5 border-2 border-blue-300 border-t-blue-600 dark:border-blue-700 dark:border-t-blue-400'></div>
-          <span className='text-sm font-medium text-gray-700 dark:text-gray-300'>加载配置中...</span>
+          <span className='text-sm font-medium text-gray-700 dark:text-gray-300'>
+            加载配置中...
+          </span>
         </div>
       </div>
     );
@@ -3908,7 +4768,9 @@ const CategoryConfig = ({
         </h4>
         <button
           onClick={() => setShowAddForm(!showAddForm)}
-          className={`px-3 py-1 text-sm rounded-lg transition-colors ${showAddForm ? buttonStyles.secondary : buttonStyles.success}`}
+          className={`px-3 py-1 text-sm rounded-lg transition-colors ${
+            showAddForm ? buttonStyles.secondary : buttonStyles.success
+          }`}
         >
           {showAddForm ? '取消' : '添加分类'}
         </button>
@@ -3952,8 +4814,18 @@ const CategoryConfig = ({
           <div className='flex justify-end'>
             <button
               onClick={handleAddCategory}
-              disabled={!newCategory.name || !newCategory.query || isLoading('addCategory')}
-              className={`w-full sm:w-auto px-4 py-2 ${!newCategory.name || !newCategory.query || isLoading('addCategory') ? buttonStyles.disabled : buttonStyles.success}`}
+              disabled={
+                !newCategory.name ||
+                !newCategory.query ||
+                isLoading('addCategory')
+              }
+              className={`w-full sm:w-auto px-4 py-2 ${
+                !newCategory.name ||
+                !newCategory.query ||
+                isLoading('addCategory')
+                  ? buttonStyles.disabled
+                  : buttonStyles.success
+              }`}
             >
               {isLoading('addCategory') ? '添加中...' : '添加'}
             </button>
@@ -4014,7 +4886,11 @@ const CategoryConfig = ({
           <button
             onClick={handleSaveOrder}
             disabled={isLoading('saveCategoryOrder')}
-            className={`px-3 py-1.5 text-sm ${isLoading('saveCategoryOrder') ? buttonStyles.disabled : buttonStyles.primary}`}
+            className={`px-3 py-1.5 text-sm ${
+              isLoading('saveCategoryOrder')
+                ? buttonStyles.disabled
+                : buttonStyles.primary
+            }`}
           >
             {isLoading('saveCategoryOrder') ? '保存中...' : '保存排序'}
           </button>
@@ -4036,15 +4912,19 @@ const CategoryConfig = ({
 };
 
 // 新增配置文件组件
-const ConfigFileComponent = ({ config, refreshConfig }: { config: AdminConfig | null; refreshConfig: () => Promise<void> }) => {
+const ConfigFileComponent = ({
+  config,
+  refreshConfig,
+}: {
+  config: AdminConfig | null;
+  refreshConfig: () => Promise<void>;
+}) => {
   const { alertModal, showAlert, hideAlert } = useAlertModal();
   const { isLoading, withLoading } = useLoadingState();
   const [configContent, setConfigContent] = useState('');
   const [subscriptionUrl, setSubscriptionUrl] = useState('');
   const [autoUpdate, setAutoUpdate] = useState(false);
   const [lastCheckTime, setLastCheckTime] = useState<string>('');
-
-
 
   useEffect(() => {
     if (config?.ConfigFile) {
@@ -4056,8 +4936,6 @@ const ConfigFileComponent = ({ config, refreshConfig }: { config: AdminConfig | 
       setLastCheckTime(config.ConfigSubscribtion.LastCheck || '');
     }
   }, [config]);
-
-
 
   // 拉取订阅配置
   const handleFetchConfig = async () => {
@@ -4107,7 +4985,7 @@ const ConfigFileComponent = ({ config, refreshConfig }: { config: AdminConfig | 
             configFile: configContent,
             subscriptionUrl,
             autoUpdate,
-            lastCheckTime: lastCheckTime || new Date().toISOString()
+            lastCheckTime: lastCheckTime || new Date().toISOString(),
           }),
         });
 
@@ -4125,14 +5003,14 @@ const ConfigFileComponent = ({ config, refreshConfig }: { config: AdminConfig | 
     });
   };
 
-
-
   if (!config) {
     return (
       <div className='flex justify-center items-center py-8'>
         <div className='flex items-center gap-3 px-6 py-3 bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20 rounded-xl border border-blue-200/50 dark:border-blue-700/50 shadow-md'>
           <div className='animate-spin rounded-full h-5 w-5 border-2 border-blue-300 border-t-blue-600 dark:border-blue-700 dark:border-t-blue-400'></div>
-          <span className='text-sm font-medium text-gray-700 dark:text-gray-300'>加载配置中...</span>
+          <span className='text-sm font-medium text-gray-700 dark:text-gray-300'>
+            加载配置中...
+          </span>
         </div>
       </div>
     );
@@ -4147,7 +5025,10 @@ const ConfigFileComponent = ({ config, refreshConfig }: { config: AdminConfig | 
             配置订阅
           </h3>
           <div className='text-sm text-gray-500 dark:text-gray-400 px-3 py-1.5 rounded-full'>
-            最后更新: {lastCheckTime ? new Date(lastCheckTime).toLocaleString('zh-CN') : '从未更新'}
+            最后更新:{' '}
+            {lastCheckTime
+              ? new Date(lastCheckTime).toLocaleString('zh-CN')
+              : '从未更新'}
           </div>
         </div>
 
@@ -4175,10 +5056,11 @@ const ConfigFileComponent = ({ config, refreshConfig }: { config: AdminConfig | 
             <button
               onClick={handleFetchConfig}
               disabled={isLoading('fetchConfig') || !subscriptionUrl.trim()}
-              className={`w-full px-6 py-3 rounded-lg font-medium transition-all duration-200 ${isLoading('fetchConfig') || !subscriptionUrl.trim()
-                ? buttonStyles.disabled
-                : buttonStyles.success
-                }`}
+              className={`w-full px-6 py-3 rounded-lg font-medium transition-all duration-200 ${
+                isLoading('fetchConfig') || !subscriptionUrl.trim()
+                  ? buttonStyles.disabled
+                  : buttonStyles.success
+              }`}
             >
               {isLoading('fetchConfig') ? (
                 <div className='flex items-center justify-center gap-2'>
@@ -4205,16 +5087,18 @@ const ConfigFileComponent = ({ config, refreshConfig }: { config: AdminConfig | 
               type='button'
               onClick={() => setAutoUpdate(!autoUpdate)}
               disabled={false}
-              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 ${autoUpdate
-                ? buttonStyles.toggleOn
-                : buttonStyles.toggleOff
-                }`}
+              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 ${
+                autoUpdate ? buttonStyles.toggleOn : buttonStyles.toggleOff
+              }`}
             >
               <span
-                className={`inline-block h-4 w-4 transform rounded-full ${buttonStyles.toggleThumb} transition-transform ${autoUpdate
-                  ? buttonStyles.toggleThumbOn
-                  : buttonStyles.toggleThumbOff
-                  }`}
+                className={`inline-block h-4 w-4 transform rounded-full ${
+                  buttonStyles.toggleThumb
+                } transition-transform ${
+                  autoUpdate
+                    ? buttonStyles.toggleThumbOn
+                    : buttonStyles.toggleThumbOff
+                }`}
               />
             </button>
           </div>
@@ -4232,7 +5116,8 @@ const ConfigFileComponent = ({ config, refreshConfig }: { config: AdminConfig | 
             disabled={false}
             className='w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 font-mono text-sm leading-relaxed resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200 hover:border-gray-400 dark:hover:border-gray-500'
             style={{
-              fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace'
+              fontFamily:
+                'ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace',
             }}
             spellCheck={false}
             data-gramm={false}
@@ -4246,10 +5131,11 @@ const ConfigFileComponent = ({ config, refreshConfig }: { config: AdminConfig | 
           <button
             onClick={handleSave}
             disabled={isLoading('saveConfig')}
-            className={`px-4 py-2 rounded-lg transition-colors ${isLoading('saveConfig')
-              ? buttonStyles.disabled
-              : buttonStyles.success
-              }`}
+            className={`px-4 py-2 rounded-lg transition-colors ${
+              isLoading('saveConfig')
+                ? buttonStyles.disabled
+                : buttonStyles.success
+            }`}
           >
             {isLoading('saveConfig') ? '保存中…' : '保存'}
           </button>
@@ -4271,7 +5157,13 @@ const ConfigFileComponent = ({ config, refreshConfig }: { config: AdminConfig | 
 };
 
 // 新增站点配置组件
-const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | null; refreshConfig: () => Promise<void> }) => {
+const SiteConfigComponent = ({
+  config,
+  refreshConfig,
+}: {
+  config: AdminConfig | null;
+  refreshConfig: () => Promise<void>;
+}) => {
   const { alertModal, showAlert, hideAlert } = useAlertModal();
   const { isLoading, withLoading } = useLoadingState();
   const [siteSettings, setSiteSettings] = useState<SiteConfig>({
@@ -4441,7 +5333,9 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
       <div className='flex justify-center items-center py-8'>
         <div className='flex items-center gap-3 px-6 py-3 bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20 rounded-xl border border-blue-200/50 dark:border-blue-700/50 shadow-md'>
           <div className='animate-spin rounded-full h-5 w-5 border-2 border-blue-300 border-t-blue-600 dark:border-blue-700 dark:border-t-blue-400'></div>
-          <span className='text-sm font-medium text-gray-700 dark:text-gray-300'>加载配置中...</span>
+          <span className='text-sm font-medium text-gray-700 dark:text-gray-300'>
+            加载配置中...
+          </span>
         </div>
       </div>
     );
@@ -4451,9 +5345,7 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
     <div className='space-y-6'>
       {/* 站点名称 */}
       <div>
-        <label
-          className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-        >
+        <label className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'>
           站点名称
         </label>
         <input
@@ -4462,15 +5354,13 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
           onChange={(e) =>
             setSiteSettings((prev) => ({ ...prev, SiteName: e.target.value }))
           }
-          className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-green-500 focus:border-transparent"
+          className='w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-green-500 focus:border-transparent'
         />
       </div>
 
       {/* 站点公告 */}
       <div>
-        <label
-          className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-        >
+        <label className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'>
           站点公告
         </label>
         <textarea
@@ -4482,16 +5372,14 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
             }))
           }
           rows={3}
-          className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-green-500 focus:border-transparent"
+          className='w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-green-500 focus:border-transparent'
         />
       </div>
 
       {/* 豆瓣数据源设置 */}
       <div className='space-y-3'>
         <div>
-          <label
-            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-          >
+          <label className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'>
             豆瓣数据代理
           </label>
           <div className='relative' data-dropdown='douban-datasource'>
@@ -4499,7 +5387,7 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
             <button
               type='button'
               onClick={() => setIsDoubanDropdownOpen(!isDoubanDropdownOpen)}
-              className="w-full px-3 py-2.5 pr-10 border border-gray-300 dark:border-gray-600 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500 transition-all duration-200 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 shadow-sm hover:border-gray-400 dark:hover:border-gray-500 text-left"
+              className='w-full px-3 py-2.5 pr-10 border border-gray-300 dark:border-gray-600 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500 transition-all duration-200 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 shadow-sm hover:border-gray-400 dark:hover:border-gray-500 text-left'
             >
               {
                 doubanDataSourceOptions.find(
@@ -4511,8 +5399,9 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
             {/* 下拉箭头 */}
             <div className='absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none'>
               <ChevronDown
-                className={`w-4 h-4 text-gray-400 dark:text-gray-500 transition-transform duration-200 ${isDoubanDropdownOpen ? 'rotate-180' : ''
-                  }`}
+                className={`w-4 h-4 text-gray-400 dark:text-gray-500 transition-transform duration-200 ${
+                  isDoubanDropdownOpen ? 'rotate-180' : ''
+                }`}
               />
             </div>
 
@@ -4527,10 +5416,11 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
                       handleDoubanDataSourceChange(option.value);
                       setIsDoubanDropdownOpen(false);
                     }}
-                    className={`w-full px-3 py-2.5 text-left text-sm transition-colors duration-150 flex items-center justify-between hover:bg-gray-100 dark:hover:bg-gray-700 ${siteSettings.DoubanProxyType === option.value
-                      ? 'bg-green-50 dark:bg-green-900/20 text-green-600 dark:text-green-400'
-                      : 'text-gray-900 dark:text-gray-100'
-                      }`}
+                    className={`w-full px-3 py-2.5 text-left text-sm transition-colors duration-150 flex items-center justify-between hover:bg-gray-100 dark:hover:bg-gray-700 ${
+                      siteSettings.DoubanProxyType === option.value
+                        ? 'bg-green-50 dark:bg-green-900/20 text-green-600 dark:text-green-400'
+                        : 'text-gray-900 dark:text-gray-100'
+                    }`}
                   >
                     <span className='truncate'>{option.label}</span>
                     {siteSettings.DoubanProxyType === option.value && (
@@ -4570,9 +5460,7 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
         {/* 豆瓣代理地址设置 - 仅在选择自定义代理时显示 */}
         {siteSettings.DoubanProxyType === 'custom' && (
           <div>
-            <label
-              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-            >
+            <label className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'>
               豆瓣代理地址
             </label>
             <input
@@ -4585,7 +5473,7 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
                   DoubanProxy: e.target.value,
                 }))
               }
-              className="w-full px-3 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500 transition-all duration-200 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 shadow-sm hover:border-gray-400 dark:hover:border-gray-500"
+              className='w-full px-3 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500 transition-all duration-200 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 shadow-sm hover:border-gray-400 dark:hover:border-gray-500'
             />
             <p className='mt-1 text-xs text-gray-500 dark:text-gray-400'>
               自定义代理服务器地址
@@ -4597,9 +5485,7 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
       {/* 豆瓣图片代理设置 */}
       <div className='space-y-3'>
         <div>
-          <label
-            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-          >
+          <label className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'>
             豆瓣图片代理
           </label>
           <div className='relative' data-dropdown='douban-image-proxy'>
@@ -4611,7 +5497,7 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
                   !isDoubanImageProxyDropdownOpen
                 )
               }
-              className="w-full px-3 py-2.5 pr-10 border border-gray-300 dark:border-gray-600 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500 transition-all duration-200 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 shadow-sm hover:border-gray-400 dark:hover:border-gray-500 text-left"
+              className='w-full px-3 py-2.5 pr-10 border border-gray-300 dark:border-gray-600 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500 transition-all duration-200 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 shadow-sm hover:border-gray-400 dark:hover:border-gray-500 text-left'
             >
               {
                 doubanImageProxyTypeOptions.find(
@@ -4623,8 +5509,9 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
             {/* 下拉箭头 */}
             <div className='absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none'>
               <ChevronDown
-                className={`w-4 h-4 text-gray-400 dark:text-gray-500 transition-transform duration-200 ${isDoubanImageProxyDropdownOpen ? 'rotate-180' : ''
-                  }`}
+                className={`w-4 h-4 text-gray-400 dark:text-gray-500 transition-transform duration-200 ${
+                  isDoubanImageProxyDropdownOpen ? 'rotate-180' : ''
+                }`}
               />
             </div>
 
@@ -4639,10 +5526,11 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
                       handleDoubanImageProxyChange(option.value);
                       setIsDoubanImageProxyDropdownOpen(false);
                     }}
-                    className={`w-full px-3 py-2.5 text-left text-sm transition-colors duration-150 flex items-center justify-between hover:bg-gray-100 dark:hover:bg-gray-700 ${siteSettings.DoubanImageProxyType === option.value
-                      ? 'bg-green-50 dark:bg-green-900/20 text-green-600 dark:text-green-400'
-                      : 'text-gray-900 dark:text-gray-100'
-                      }`}
+                    className={`w-full px-3 py-2.5 text-left text-sm transition-colors duration-150 flex items-center justify-between hover:bg-gray-100 dark:hover:bg-gray-700 ${
+                      siteSettings.DoubanImageProxyType === option.value
+                        ? 'bg-green-50 dark:bg-green-900/20 text-green-600 dark:text-green-400'
+                        : 'text-gray-900 dark:text-gray-100'
+                    }`}
                   >
                     <span className='truncate'>{option.label}</span>
                     {siteSettings.DoubanImageProxyType === option.value && (
@@ -4682,9 +5570,7 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
         {/* 豆瓣代理地址设置 - 仅在选择自定义代理时显示 */}
         {siteSettings.DoubanImageProxyType === 'custom' && (
           <div>
-            <label
-              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-            >
+            <label className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'>
               豆瓣图片代理地址
             </label>
             <input
@@ -4697,7 +5583,7 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
                   DoubanImageProxy: e.target.value,
                 }))
               }
-              className="w-full px-3 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500 transition-all duration-200 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 shadow-sm hover:border-gray-400 dark:hover:border-gray-500"
+              className='w-full px-3 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500 transition-all duration-200 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 shadow-sm hover:border-gray-400 dark:hover:border-gray-500'
             />
             <p className='mt-1 text-xs text-gray-500 dark:text-gray-400'>
               自定义图片代理服务器地址
@@ -4747,9 +5633,7 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
       {/* 启用关键词过滤 */}
       <div>
         <div className='flex items-center justify-between'>
-          <label
-            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-          >
+          <label className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'>
             启用关键词过滤
           </label>
           <button
@@ -4760,16 +5644,20 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
                 DisableYellowFilter: !prev.DisableYellowFilter,
               }))
             }
-            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 ${!siteSettings.DisableYellowFilter
-              ? buttonStyles.toggleOn
-              : buttonStyles.toggleOff
-              }`}
+            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 ${
+              !siteSettings.DisableYellowFilter
+                ? buttonStyles.toggleOn
+                : buttonStyles.toggleOff
+            }`}
           >
             <span
-              className={`inline-block h-4 w-4 transform rounded-full ${buttonStyles.toggleThumb} transition-transform ${!siteSettings.DisableYellowFilter
-                ? buttonStyles.toggleThumbOn
-                : buttonStyles.toggleThumbOff
-                }`}
+              className={`inline-block h-4 w-4 transform rounded-full ${
+                buttonStyles.toggleThumb
+              } transition-transform ${
+                !siteSettings.DisableYellowFilter
+                  ? buttonStyles.toggleThumbOn
+                  : buttonStyles.toggleThumbOff
+              }`}
             />
           </button>
         </div>
@@ -4781,10 +5669,9 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
       {/* 显示成人内容 */}
       <div>
         <div className='flex items-center justify-between'>
-          <label
-            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-          >
-            显示成人内容 <span className='text-red-600 dark:text-red-400'>🔞</span>
+          <label className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'>
+            显示成人内容{' '}
+            <span className='text-red-600 dark:text-red-400'>🔞</span>
           </label>
           <button
             type='button'
@@ -4794,16 +5681,20 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
                 ShowAdultContent: !prev.ShowAdultContent,
               }))
             }
-            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 ${siteSettings.ShowAdultContent
-              ? 'bg-gradient-to-r from-red-600 to-pink-600 focus:ring-red-500'
-              : buttonStyles.toggleOff + ' focus:ring-gray-500'
-              }`}
+            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 ${
+              siteSettings.ShowAdultContent
+                ? 'bg-gradient-to-r from-red-600 to-pink-600 focus:ring-red-500'
+                : buttonStyles.toggleOff + ' focus:ring-gray-500'
+            }`}
           >
             <span
-              className={`inline-block h-4 w-4 transform rounded-full ${buttonStyles.toggleThumb} transition-transform ${siteSettings.ShowAdultContent
-                ? buttonStyles.toggleThumbOn
-                : buttonStyles.toggleThumbOff
-                }`}
+              className={`inline-block h-4 w-4 transform rounded-full ${
+                buttonStyles.toggleThumb
+              } transition-transform ${
+                siteSettings.ShowAdultContent
+                  ? buttonStyles.toggleThumbOn
+                  : buttonStyles.toggleThumbOff
+              }`}
             />
           </button>
         </div>
@@ -4815,9 +5706,7 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
       {/* 流式搜索 */}
       <div>
         <div className='flex items-center justify-between'>
-          <label
-            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-          >
+          <label className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'>
             启用流式搜索
           </label>
           <button
@@ -4828,16 +5717,20 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
                 FluidSearch: !prev.FluidSearch,
               }))
             }
-            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 ${siteSettings.FluidSearch
-              ? buttonStyles.toggleOn
-              : buttonStyles.toggleOff
-              }`}
+            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 ${
+              siteSettings.FluidSearch
+                ? buttonStyles.toggleOn
+                : buttonStyles.toggleOff
+            }`}
           >
             <span
-              className={`inline-block h-4 w-4 transform rounded-full ${buttonStyles.toggleThumb} transition-transform ${siteSettings.FluidSearch
-                ? buttonStyles.toggleThumbOn
-                : buttonStyles.toggleThumbOff
-                }`}
+              className={`inline-block h-4 w-4 transform rounded-full ${
+                buttonStyles.toggleThumb
+              } transition-transform ${
+                siteSettings.FluidSearch
+                  ? buttonStyles.toggleThumbOn
+                  : buttonStyles.toggleThumbOff
+              }`}
             />
           </button>
         </div>
@@ -4861,13 +5754,25 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
             type='password'
             value={siteSettings.TMDBApiKey || ''}
             onChange={(e) =>
-              setSiteSettings((prev) => ({ ...prev, TMDBApiKey: e.target.value }))
+              setSiteSettings((prev) => ({
+                ...prev,
+                TMDBApiKey: e.target.value,
+              }))
             }
             placeholder='请输入TMDB API Key'
             className='w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-green-500 focus:border-transparent'
           />
           <p className='mt-1 text-xs text-gray-500 dark:text-gray-400'>
-            请在 <a href='https://www.themoviedb.org/settings/api' target='_blank' rel='noopener noreferrer' className='text-blue-500 hover:text-blue-600'>TMDB 官网</a> 申请免费的 API Key
+            请在{' '}
+            <a
+              href='https://www.themoviedb.org/settings/api'
+              target='_blank'
+              rel='noopener noreferrer'
+              className='text-blue-500 hover:text-blue-600'
+            >
+              TMDB 官网
+            </a>{' '}
+            申请免费的 API Key
           </p>
         </div>
 
@@ -4879,7 +5784,10 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
           <select
             value={siteSettings.TMDBLanguage || 'zh-CN'}
             onChange={(e) =>
-              setSiteSettings((prev) => ({ ...prev, TMDBLanguage: e.target.value }))
+              setSiteSettings((prev) => ({
+                ...prev,
+                TMDBLanguage: e.target.value,
+              }))
             }
             className='w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-green-500 focus:border-transparent'
           >
@@ -4917,7 +5825,9 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
           >
             <span
               className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                siteSettings.EnableTMDBActorSearch ? 'translate-x-6' : 'translate-x-1'
+                siteSettings.EnableTMDBActorSearch
+                  ? 'translate-x-6'
+                  : 'translate-x-1'
               }`}
             />
           </button>
@@ -4929,10 +5839,11 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
         <button
           onClick={handleSave}
           disabled={isLoading('saveSiteConfig')}
-          className={`px-4 py-2 ${isLoading('saveSiteConfig')
-            ? buttonStyles.disabled
-            : buttonStyles.success
-            } rounded-lg transition-colors`}
+          className={`px-4 py-2 ${
+            isLoading('saveSiteConfig')
+              ? buttonStyles.disabled
+              : buttonStyles.success
+          } rounded-lg transition-colors`}
         >
           {isLoading('saveSiteConfig') ? '保存中…' : '保存'}
         </button>
@@ -4964,7 +5875,8 @@ const LiveSourceConfig = ({
   const { isLoading, withLoading } = useLoadingState();
   const [liveSources, setLiveSources] = useState<LiveDataSource[]>([]);
   const [showAddForm, setShowAddForm] = useState(false);
-  const [editingLiveSource, setEditingLiveSource] = useState<LiveDataSource | null>(null);
+  const [editingLiveSource, setEditingLiveSource] =
+    useState<LiveDataSource | null>(null);
   const [orderChanged, setOrderChanged] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [newLiveSource, setNewLiveSource] = useState<LiveDataSource>({
@@ -5027,13 +5939,17 @@ const LiveSourceConfig = ({
     const target = liveSources.find((s) => s.key === key);
     if (!target) return;
     const action = target.disabled ? 'enable' : 'disable';
-    withLoading(`toggleLiveSource_${key}`, () => callLiveSourceApi({ action, key })).catch(() => {
+    withLoading(`toggleLiveSource_${key}`, () =>
+      callLiveSourceApi({ action, key })
+    ).catch(() => {
       console.error('操作失败', action, key);
     });
   };
 
   const handleDelete = (key: string) => {
-    withLoading(`deleteLiveSource_${key}`, () => callLiveSourceApi({ action: 'delete', key })).catch(() => {
+    withLoading(`deleteLiveSource_${key}`, () =>
+      callLiveSourceApi({ action: 'delete', key })
+    ).catch(() => {
       console.error('操作失败', 'delete', key);
     });
   };
@@ -5057,7 +5973,12 @@ const LiveSourceConfig = ({
 
         // 刷新成功后重新获取配置
         await refreshConfig();
-        showAlert({ type: 'success', title: '刷新成功', message: '直播源已刷新', timer: 2000 });
+        showAlert({
+          type: 'success',
+          title: '刷新成功',
+          message: '直播源已刷新',
+          timer: 2000,
+        });
       } catch (err) {
         showError(err instanceof Error ? err.message : '刷新失败', showAlert);
         throw err;
@@ -5094,7 +6015,8 @@ const LiveSourceConfig = ({
   };
 
   const handleEditLiveSource = () => {
-    if (!editingLiveSource || !editingLiveSource.name || !editingLiveSource.url) return;
+    if (!editingLiveSource || !editingLiveSource.name || !editingLiveSource.url)
+      return;
     withLoading('editLiveSource', async () => {
       await callLiveSourceApi({
         action: 'edit',
@@ -5125,7 +6047,9 @@ const LiveSourceConfig = ({
 
   const handleSaveOrder = () => {
     const order = liveSources.map((s) => s.key);
-    withLoading('saveLiveSourceOrder', () => callLiveSourceApi({ action: 'sort', order }))
+    withLoading('saveLiveSourceOrder', () =>
+      callLiveSourceApi({ action: 'sort', order })
+    )
       .then(() => {
         setOrderChanged(false);
       })
@@ -5183,14 +6107,17 @@ const LiveSourceConfig = ({
           {liveSource.ua || '-'}
         </td>
         <td className='px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100 text-center'>
-          {liveSource.channelNumber && liveSource.channelNumber > 0 ? liveSource.channelNumber : '-'}
+          {liveSource.channelNumber && liveSource.channelNumber > 0
+            ? liveSource.channelNumber
+            : '-'}
         </td>
         <td className='px-6 py-4 whitespace-nowrap max-w-[1rem]'>
           <span
-            className={`px-2 py-1 text-xs rounded-full ${!liveSource.disabled
-              ? 'bg-green-100 dark:bg-green-900/20 text-green-800 dark:text-green-300'
-              : 'bg-red-100 dark:bg-red-900/20 text-red-800 dark:text-red-300'
-              }`}
+            className={`px-2 py-1 text-xs rounded-full ${
+              !liveSource.disabled
+                ? 'bg-green-100 dark:bg-green-900/20 text-green-800 dark:text-green-300'
+                : 'bg-red-100 dark:bg-red-900/20 text-red-800 dark:text-red-300'
+            }`}
           >
             {!liveSource.disabled ? '启用中' : '已禁用'}
           </span>
@@ -5199,10 +6126,15 @@ const LiveSourceConfig = ({
           <button
             onClick={() => handleToggleEnable(liveSource.key)}
             disabled={isLoading(`toggleLiveSource_${liveSource.key}`)}
-            className={`inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium ${!liveSource.disabled
-              ? buttonStyles.roundedDanger
-              : buttonStyles.roundedSuccess
-              } transition-colors ${isLoading(`toggleLiveSource_${liveSource.key}`) ? 'opacity-50 cursor-not-allowed' : ''}`}
+            className={`inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium ${
+              !liveSource.disabled
+                ? buttonStyles.roundedDanger
+                : buttonStyles.roundedSuccess
+            } transition-colors ${
+              isLoading(`toggleLiveSource_${liveSource.key}`)
+                ? 'opacity-50 cursor-not-allowed'
+                : ''
+            }`}
           >
             {!liveSource.disabled ? '禁用' : '启用'}
           </button>
@@ -5211,14 +6143,22 @@ const LiveSourceConfig = ({
               <button
                 onClick={() => setEditingLiveSource(liveSource)}
                 disabled={isLoading(`editLiveSource_${liveSource.key}`)}
-                className={`${buttonStyles.roundedPrimary} ${isLoading(`editLiveSource_${liveSource.key}`) ? 'opacity-50 cursor-not-allowed' : ''}`}
+                className={`${buttonStyles.roundedPrimary} ${
+                  isLoading(`editLiveSource_${liveSource.key}`)
+                    ? 'opacity-50 cursor-not-allowed'
+                    : ''
+                }`}
               >
                 编辑
               </button>
               <button
                 onClick={() => handleDelete(liveSource.key)}
                 disabled={isLoading(`deleteLiveSource_${liveSource.key}`)}
-                className={`${buttonStyles.roundedSecondary} ${isLoading(`deleteLiveSource_${liveSource.key}`) ? 'opacity-50 cursor-not-allowed' : ''}`}
+                className={`${buttonStyles.roundedSecondary} ${
+                  isLoading(`deleteLiveSource_${liveSource.key}`)
+                    ? 'opacity-50 cursor-not-allowed'
+                    : ''
+                }`}
               >
                 删除
               </button>
@@ -5234,7 +6174,9 @@ const LiveSourceConfig = ({
       <div className='flex justify-center items-center py-8'>
         <div className='flex items-center gap-3 px-6 py-3 bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20 rounded-xl border border-blue-200/50 dark:border-blue-700/50 shadow-md'>
           <div className='animate-spin rounded-full h-5 w-5 border-2 border-blue-300 border-t-blue-600 dark:border-blue-700 dark:border-t-blue-400'></div>
-          <span className='text-sm font-medium text-gray-700 dark:text-gray-300'>加载配置中...</span>
+          <span className='text-sm font-medium text-gray-700 dark:text-gray-300'>
+            加载配置中...
+          </span>
         </div>
       </div>
     );
@@ -5251,16 +6193,23 @@ const LiveSourceConfig = ({
           <button
             onClick={handleRefreshLiveSources}
             disabled={isRefreshing || isLoading('refreshLiveSources')}
-            className={`px-3 py-1.5 text-sm font-medium flex items-center space-x-2 ${isRefreshing || isLoading('refreshLiveSources')
-              ? 'bg-gray-400 dark:bg-gray-600 cursor-not-allowed text-white rounded-lg'
-              : 'bg-blue-600 hover:bg-blue-700 dark:bg-blue-600 dark:hover:bg-blue-700 text-white rounded-lg transition-colors'
-              }`}
+            className={`px-3 py-1.5 text-sm font-medium flex items-center space-x-2 ${
+              isRefreshing || isLoading('refreshLiveSources')
+                ? 'bg-gray-400 dark:bg-gray-600 cursor-not-allowed text-white rounded-lg'
+                : 'bg-blue-600 hover:bg-blue-700 dark:bg-blue-600 dark:hover:bg-blue-700 text-white rounded-lg transition-colors'
+            }`}
           >
-            <span>{isRefreshing || isLoading('refreshLiveSources') ? '刷新中...' : '刷新直播源'}</span>
+            <span>
+              {isRefreshing || isLoading('refreshLiveSources')
+                ? '刷新中...'
+                : '刷新直播源'}
+            </span>
           </button>
           <button
             onClick={() => setShowAddForm(!showAddForm)}
-            className={showAddForm ? buttonStyles.secondary : buttonStyles.success}
+            className={
+              showAddForm ? buttonStyles.secondary : buttonStyles.success
+            }
           >
             {showAddForm ? '取消' : '添加直播源'}
           </button>
@@ -5315,13 +6264,24 @@ const LiveSourceConfig = ({
               }
               className='px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100'
             />
-
           </div>
           <div className='flex justify-end'>
             <button
               onClick={handleAddLiveSource}
-              disabled={!newLiveSource.name || !newLiveSource.key || !newLiveSource.url || isLoading('addLiveSource')}
-              className={`w-full sm:w-auto px-4 py-2 ${!newLiveSource.name || !newLiveSource.key || !newLiveSource.url || isLoading('addLiveSource') ? buttonStyles.disabled : buttonStyles.success}`}
+              disabled={
+                !newLiveSource.name ||
+                !newLiveSource.key ||
+                !newLiveSource.url ||
+                isLoading('addLiveSource')
+              }
+              className={`w-full sm:w-auto px-4 py-2 ${
+                !newLiveSource.name ||
+                !newLiveSource.key ||
+                !newLiveSource.url ||
+                isLoading('addLiveSource')
+                  ? buttonStyles.disabled
+                  : buttonStyles.success
+              }`}
             >
               {isLoading('addLiveSource') ? '添加中...' : '添加'}
             </button>
@@ -5352,7 +6312,9 @@ const LiveSourceConfig = ({
                 type='text'
                 value={editingLiveSource.name}
                 onChange={(e) =>
-                  setEditingLiveSource((prev) => prev ? ({ ...prev, name: e.target.value }) : null)
+                  setEditingLiveSource((prev) =>
+                    prev ? { ...prev, name: e.target.value } : null
+                  )
                 }
                 className='w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100'
               />
@@ -5376,7 +6338,9 @@ const LiveSourceConfig = ({
                 type='text'
                 value={editingLiveSource.url}
                 onChange={(e) =>
-                  setEditingLiveSource((prev) => prev ? ({ ...prev, url: e.target.value }) : null)
+                  setEditingLiveSource((prev) =>
+                    prev ? { ...prev, url: e.target.value } : null
+                  )
                 }
                 className='w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100'
               />
@@ -5389,7 +6353,9 @@ const LiveSourceConfig = ({
                 type='text'
                 value={editingLiveSource.epg}
                 onChange={(e) =>
-                  setEditingLiveSource((prev) => prev ? ({ ...prev, epg: e.target.value }) : null)
+                  setEditingLiveSource((prev) =>
+                    prev ? { ...prev, epg: e.target.value } : null
+                  )
                 }
                 className='w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100'
               />
@@ -5402,7 +6368,9 @@ const LiveSourceConfig = ({
                 type='text'
                 value={editingLiveSource.ua}
                 onChange={(e) =>
-                  setEditingLiveSource((prev) => prev ? ({ ...prev, ua: e.target.value }) : null)
+                  setEditingLiveSource((prev) =>
+                    prev ? { ...prev, ua: e.target.value } : null
+                  )
                 }
                 className='w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100'
               />
@@ -5417,8 +6385,18 @@ const LiveSourceConfig = ({
             </button>
             <button
               onClick={handleEditLiveSource}
-              disabled={!editingLiveSource.name || !editingLiveSource.url || isLoading('editLiveSource')}
-              className={`${!editingLiveSource.name || !editingLiveSource.url || isLoading('editLiveSource') ? buttonStyles.disabled : buttonStyles.success}`}
+              disabled={
+                !editingLiveSource.name ||
+                !editingLiveSource.url ||
+                isLoading('editLiveSource')
+              }
+              className={`${
+                !editingLiveSource.name ||
+                !editingLiveSource.url ||
+                isLoading('editLiveSource')
+                  ? buttonStyles.disabled
+                  : buttonStyles.success
+              }`}
             >
               {isLoading('editLiveSource') ? '保存中...' : '保存'}
             </button>
@@ -5427,7 +6405,10 @@ const LiveSourceConfig = ({
       )}
 
       {/* 直播源表格 */}
-      <div className='border border-gray-200 dark:border-gray-700 rounded-lg max-h-[28rem] overflow-y-auto overflow-x-auto relative' data-table="live-source-list">
+      <div
+        className='border border-gray-200 dark:border-gray-700 rounded-lg max-h-[28rem] overflow-y-auto overflow-x-auto relative'
+        data-table='live-source-list'
+      >
         <table className='min-w-full divide-y divide-gray-200 dark:divide-gray-700'>
           <thead className='bg-gray-50 dark:bg-gray-900 sticky top-0 z-10'>
             <tr>
@@ -5485,7 +6466,11 @@ const LiveSourceConfig = ({
           <button
             onClick={handleSaveOrder}
             disabled={isLoading('saveLiveSourceOrder')}
-            className={`px-3 py-1.5 text-sm ${isLoading('saveLiveSourceOrder') ? buttonStyles.disabled : buttonStyles.primary}`}
+            className={`px-3 py-1.5 text-sm ${
+              isLoading('saveLiveSourceOrder')
+                ? buttonStyles.disabled
+                : buttonStyles.primary
+            }`}
           >
             {isLoading('saveLiveSourceOrder') ? '保存中...' : '保存排序'}
           </button>
@@ -5502,8 +6487,6 @@ const LiveSourceConfig = ({
         timer={alertModal.timer}
         showConfirm={alertModal.showConfirm}
       />
-
-
     </div>
   );
 };
@@ -5518,12 +6501,25 @@ const NetDiskConfig = ({
 }) => {
   const { alertModal, showAlert, hideAlert } = useAlertModal();
   const { isLoading, withLoading } = useLoadingState();
-  
+
   const [netDiskSettings, setNetDiskSettings] = useState({
     enabled: true,
     pansouUrl: 'https://so.252035.xyz',
     timeout: 30,
-    enabledCloudTypes: ['baidu', 'aliyun', 'quark', 'tianyi', 'uc', 'mobile', '115', 'pikpak', 'xunlei', '123', 'magnet', 'ed2k']
+    enabledCloudTypes: [
+      'baidu',
+      'aliyun',
+      'quark',
+      'tianyi',
+      'uc',
+      'mobile',
+      '115',
+      'pikpak',
+      'xunlei',
+      '123',
+      'magnet',
+      'ed2k',
+    ],
   });
 
   // 网盘类型选项
@@ -5539,7 +6535,7 @@ const NetDiskConfig = ({
     { key: 'xunlei', name: '迅雷网盘', icon: '⚡' },
     { key: '123', name: '123网盘', icon: '🔢' },
     { key: 'magnet', name: '磁力链接', icon: '🧲' },
-    { key: 'ed2k', name: '电驴链接', icon: '🐴' }
+    { key: 'ed2k', name: '电驴链接', icon: '🐴' },
   ];
 
   // 从config加载设置
@@ -5549,7 +6545,13 @@ const NetDiskConfig = ({
         enabled: config.NetDiskConfig.enabled ?? true,
         pansouUrl: config.NetDiskConfig.pansouUrl || 'https://so.252035.xyz',
         timeout: config.NetDiskConfig.timeout || 30,
-        enabledCloudTypes: config.NetDiskConfig.enabledCloudTypes || ['baidu', 'aliyun', 'quark', 'tianyi', 'uc']
+        enabledCloudTypes: config.NetDiskConfig.enabledCloudTypes || [
+          'baidu',
+          'aliyun',
+          'quark',
+          'tianyi',
+          'uc',
+        ],
       });
     }
   }, [config]);
@@ -5561,7 +6563,7 @@ const NetDiskConfig = ({
         const response = await fetch('/api/admin/netdisk', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(netDiskSettings)
+          body: JSON.stringify(netDiskSettings),
         });
 
         if (!response.ok) {
@@ -5579,19 +6581,21 @@ const NetDiskConfig = ({
 
   // 处理网盘类型选择
   const handleCloudTypeChange = (type: string, enabled: boolean) => {
-    setNetDiskSettings(prev => ({
+    setNetDiskSettings((prev) => ({
       ...prev,
-      enabledCloudTypes: enabled 
+      enabledCloudTypes: enabled
         ? [...prev.enabledCloudTypes, type]
-        : prev.enabledCloudTypes.filter(t => t !== type)
+        : prev.enabledCloudTypes.filter((t) => t !== type),
     }));
   };
 
   // 全选/取消全选网盘类型
   const handleSelectAll = (selectAll: boolean) => {
-    setNetDiskSettings(prev => ({
+    setNetDiskSettings((prev) => ({
       ...prev,
-      enabledCloudTypes: selectAll ? CLOUD_TYPE_OPTIONS.map(option => option.key) : []
+      enabledCloudTypes: selectAll
+        ? CLOUD_TYPE_OPTIONS.map((option) => option.key)
+        : [],
     }));
   };
 
@@ -5600,15 +6604,23 @@ const NetDiskConfig = ({
       {/* 基础设置 */}
       <div className='bg-white dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700 shadow-sm'>
         <div className='mb-6'>
-          <h3 className='text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2'>基础设置</h3>
+          <h3 className='text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2'>
+            基础设置
+          </h3>
           <div className='flex items-center space-x-2 text-sm text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/20 px-3 py-2 rounded-lg'>
             <svg className='h-4 w-4' fill='currentColor' viewBox='0 0 20 20'>
-              <path fillRule='evenodd' d='M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z' clipRule='evenodd' />
+              <path
+                fillRule='evenodd'
+                d='M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z'
+                clipRule='evenodd'
+              />
             </svg>
-            <span>📡 集成开源项目 <strong>PanSou</strong> 提供网盘资源搜索功能</span>
-            <a 
-              href='https://github.com/fish2018/pansou' 
-              target='_blank' 
+            <span>
+              📡 集成开源项目 <strong>PanSou</strong> 提供网盘资源搜索功能
+            </span>
+            <a
+              href='https://github.com/fish2018/pansou'
+              target='_blank'
               rel='noopener noreferrer'
               className='text-blue-700 dark:text-blue-300 hover:underline font-medium'
             >
@@ -5616,7 +6628,7 @@ const NetDiskConfig = ({
             </a>
           </div>
         </div>
-        
+
         {/* 启用网盘搜索 */}
         <div className='space-y-4'>
           <div className='flex items-center space-x-3'>
@@ -5624,10 +6636,17 @@ const NetDiskConfig = ({
               <input
                 type='checkbox'
                 checked={netDiskSettings.enabled}
-                onChange={(e) => setNetDiskSettings(prev => ({ ...prev, enabled: e.target.checked }))}
+                onChange={(e) =>
+                  setNetDiskSettings((prev) => ({
+                    ...prev,
+                    enabled: e.target.checked,
+                  }))
+                }
                 className='w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700'
               />
-              <span className='ml-2 text-sm font-medium text-gray-900 dark:text-gray-100'>启用网盘搜索功能</span>
+              <span className='ml-2 text-sm font-medium text-gray-900 dark:text-gray-100'>
+                启用网盘搜索功能
+              </span>
             </label>
           </div>
 
@@ -5639,7 +6658,12 @@ const NetDiskConfig = ({
             <input
               type='url'
               value={netDiskSettings.pansouUrl}
-              onChange={(e) => setNetDiskSettings(prev => ({ ...prev, pansouUrl: e.target.value }))}
+              onChange={(e) =>
+                setNetDiskSettings((prev) => ({
+                  ...prev,
+                  pansouUrl: e.target.value,
+                }))
+              }
               placeholder='https://so.252035.xyz'
               className='w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-blue-500 focus:border-blue-500'
             />
@@ -5653,8 +6677,16 @@ const NetDiskConfig = ({
                 rel='noopener noreferrer'
                 className='inline-flex items-center px-2 py-1 text-xs font-medium text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/20 hover:bg-blue-100 dark:hover:bg-blue-900/30 rounded-md transition-colors whitespace-nowrap'
               >
-                <svg className='h-3 w-3 mr-1' fill='currentColor' viewBox='0 0 20 20'>
-                  <path fillRule='evenodd' d='M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z' clipRule='evenodd' />
+                <svg
+                  className='h-3 w-3 mr-1'
+                  fill='currentColor'
+                  viewBox='0 0 20 20'
+                >
+                  <path
+                    fillRule='evenodd'
+                    d='M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z'
+                    clipRule='evenodd'
+                  />
                 </svg>
                 搭建教程
               </a>
@@ -5671,7 +6703,12 @@ const NetDiskConfig = ({
               min='10'
               max='120'
               value={netDiskSettings.timeout}
-              onChange={(e) => setNetDiskSettings(prev => ({ ...prev, timeout: parseInt(e.target.value) || 30 }))}
+              onChange={(e) =>
+                setNetDiskSettings((prev) => ({
+                  ...prev,
+                  timeout: parseInt(e.target.value) || 30,
+                }))
+              }
               className='w-32 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-blue-500 focus:border-blue-500'
             />
           </div>
@@ -5681,7 +6718,9 @@ const NetDiskConfig = ({
       {/* 支持的网盘类型 */}
       <div className='bg-white dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700 shadow-sm'>
         <div className='flex items-center justify-between mb-4'>
-          <h3 className='text-lg font-semibold text-gray-900 dark:text-gray-100'>支持的网盘类型</h3>
+          <h3 className='text-lg font-semibold text-gray-900 dark:text-gray-100'>
+            支持的网盘类型
+          </h3>
           <div className='space-x-2'>
             <button
               onClick={() => handleSelectAll(true)}
@@ -5707,7 +6746,9 @@ const NetDiskConfig = ({
               <input
                 type='checkbox'
                 checked={netDiskSettings.enabledCloudTypes.includes(option.key)}
-                onChange={(e) => handleCloudTypeChange(option.key, e.target.checked)}
+                onChange={(e) =>
+                  handleCloudTypeChange(option.key, e.target.checked)
+                }
                 className='w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700'
               />
               <span className='text-lg'>{option.icon}</span>
@@ -5720,10 +6761,15 @@ const NetDiskConfig = ({
 
         <div className='mt-4 p-3 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg'>
           <div className='flex items-start space-x-2'>
-            <CheckCircle size={16} className='text-blue-600 dark:text-blue-400 mt-0.5 flex-shrink-0' />
+            <CheckCircle
+              size={16}
+              className='text-blue-600 dark:text-blue-400 mt-0.5 flex-shrink-0'
+            />
             <div className='text-sm text-blue-700 dark:text-blue-300'>
               <p className='font-medium mb-1'>配置说明</p>
-              <p>选择要在搜索结果中显示的网盘类型。取消选择的类型不会出现在搜索结果中。</p>
+              <p>
+                选择要在搜索结果中显示的网盘类型。取消选择的类型不会出现在搜索结果中。
+              </p>
             </div>
           </div>
         </div>
@@ -5735,7 +6781,9 @@ const NetDiskConfig = ({
           onClick={handleSave}
           disabled={isLoading('saveNetDiskConfig')}
           className={`px-4 py-2 ${
-            isLoading('saveNetDiskConfig') ? buttonStyles.disabled : buttonStyles.success
+            isLoading('saveNetDiskConfig')
+              ? buttonStyles.disabled
+              : buttonStyles.success
           } rounded-lg transition-colors`}
         >
           {isLoading('saveNetDiskConfig') ? '保存中…' : '保存配置'}
@@ -5779,6 +6827,7 @@ function AdminPageClient() {
     configFile: false,
     cacheManager: false,
     dataMigration: false,
+    liveStats: false,
   });
 
   // 获取管理员配置
@@ -5906,7 +6955,10 @@ function AdminPageClient() {
               isExpanded={expandedTabs.configFile}
               onToggle={() => toggleTab('configFile')}
             >
-              <ConfigFileComponent config={config} refreshConfig={fetchConfig} />
+              <ConfigFileComponent
+                config={config}
+                refreshConfig={fetchConfig}
+              />
             </CollapsibleTab>
           )}
 
@@ -5958,7 +7010,10 @@ function AdminPageClient() {
             <CollapsibleTab
               title='源检测'
               icon={
-                <TestTube size={20} className='text-gray-600 dark:text-gray-400' />
+                <TestTube
+                  size={20}
+                  className='text-gray-600 dark:text-gray-400'
+                />
               }
               isExpanded={expandedTabs.sourceTest}
               onToggle={() => toggleTab('sourceTest')}
@@ -6012,10 +7067,7 @@ function AdminPageClient() {
             <CollapsibleTab
               title='AI推荐配置'
               icon={
-                <Brain
-                  size={20}
-                  className='text-gray-600 dark:text-gray-400'
-                />
+                <Brain size={20} className='text-gray-600 dark:text-gray-400' />
               }
               isExpanded={expandedTabs.aiRecommendConfig}
               onToggle={() => toggleTab('aiRecommendConfig')}
@@ -6027,10 +7079,7 @@ function AdminPageClient() {
             <CollapsibleTab
               title='YouTube配置'
               icon={
-                <Video
-                  size={20}
-                  className='text-gray-600 dark:text-gray-400'
-                />
+                <Video size={20} className='text-gray-600 dark:text-gray-400' />
               }
               isExpanded={expandedTabs.youtubeConfig}
               onToggle={() => toggleTab('youtubeConfig')}
@@ -6050,7 +7099,10 @@ function AdminPageClient() {
               isExpanded={expandedTabs.tvboxSecurityConfig}
               onToggle={() => toggleTab('tvboxSecurityConfig')}
             >
-              <TVBoxSecurityConfig config={config} refreshConfig={fetchConfig} />
+              <TVBoxSecurityConfig
+                config={config}
+                refreshConfig={fetchConfig}
+              />
             </CollapsibleTab>
 
             {/* Telegram 登录配置 - 仅站长可见 */}
@@ -6148,61 +7200,92 @@ function AdminPageClient() {
       />
 
       {/* 重置配置确认弹窗 */}
-      {showResetConfigModal && createPortal(
-        <div className='fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4' onClick={() => setShowResetConfigModal(false)}>
-          <div className='bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-2xl w-full' onClick={(e) => e.stopPropagation()}>
-            <div className='p-6'>
-              <div className='flex items-center justify-between mb-6'>
-                <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
-                  确认重置配置
-                </h3>
-                <button
-                  onClick={() => setShowResetConfigModal(false)}
-                  className='text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors'
-                >
-                  <svg className='w-6 h-6' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                    <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M6 18L18 6M6 6l12 12' />
-                  </svg>
-                </button>
-              </div>
-
-              <div className='mb-6'>
-                <div className='bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4 mb-4'>
-                  <div className='flex items-center space-x-2 mb-2'>
-                    <svg className='w-5 h-5 text-yellow-600 dark:text-yellow-400' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                      <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z' />
+      {showResetConfigModal &&
+        createPortal(
+          <div
+            className='fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4'
+            onClick={() => setShowResetConfigModal(false)}
+          >
+            <div
+              className='bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-2xl w-full'
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className='p-6'>
+                <div className='flex items-center justify-between mb-6'>
+                  <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
+                    确认重置配置
+                  </h3>
+                  <button
+                    onClick={() => setShowResetConfigModal(false)}
+                    className='text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors'
+                  >
+                    <svg
+                      className='w-6 h-6'
+                      fill='none'
+                      stroke='currentColor'
+                      viewBox='0 0 24 24'
+                    >
+                      <path
+                        strokeLinecap='round'
+                        strokeLinejoin='round'
+                        strokeWidth={2}
+                        d='M6 18L18 6M6 6l12 12'
+                      />
                     </svg>
-                    <span className='text-sm font-medium text-yellow-800 dark:text-yellow-300'>
-                      ⚠️ 危险操作警告
-                    </span>
+                  </button>
+                </div>
+
+                <div className='mb-6'>
+                  <div className='bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4 mb-4'>
+                    <div className='flex items-center space-x-2 mb-2'>
+                      <svg
+                        className='w-5 h-5 text-yellow-600 dark:text-yellow-400'
+                        fill='none'
+                        stroke='currentColor'
+                        viewBox='0 0 24 24'
+                      >
+                        <path
+                          strokeLinecap='round'
+                          strokeLinejoin='round'
+                          strokeWidth={2}
+                          d='M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z'
+                        />
+                      </svg>
+                      <span className='text-sm font-medium text-yellow-800 dark:text-yellow-300'>
+                        ⚠️ 危险操作警告
+                      </span>
+                    </div>
+                    <p className='text-sm text-yellow-700 dark:text-yellow-400'>
+                      此操作将重置用户封禁和管理员设置、自定义视频源，站点配置将重置为默认值，是否继续？
+                    </p>
                   </div>
-                  <p className='text-sm text-yellow-700 dark:text-yellow-400'>
-                    此操作将重置用户封禁和管理员设置、自定义视频源，站点配置将重置为默认值，是否继续？
-                  </p>
+                </div>
+
+                {/* 操作按钮 */}
+                <div className='flex justify-end space-x-3'>
+                  <button
+                    onClick={() => setShowResetConfigModal(false)}
+                    className={`px-6 py-2.5 text-sm font-medium ${buttonStyles.secondary}`}
+                  >
+                    取消
+                  </button>
+                  <button
+                    onClick={handleConfirmResetConfig}
+                    disabled={isLoading('resetConfig')}
+                    className={`px-6 py-2.5 text-sm font-medium ${
+                      isLoading('resetConfig')
+                        ? buttonStyles.disabled
+                        : buttonStyles.danger
+                    }`}
+                  >
+                    {isLoading('resetConfig') ? '重置中...' : '确认重置'}
+                  </button>
                 </div>
               </div>
-
-              {/* 操作按钮 */}
-              <div className='flex justify-end space-x-3'>
-                <button
-                  onClick={() => setShowResetConfigModal(false)}
-                  className={`px-6 py-2.5 text-sm font-medium ${buttonStyles.secondary}`}
-                >
-                  取消
-                </button>
-                <button
-                  onClick={handleConfirmResetConfig}
-                  disabled={isLoading('resetConfig')}
-                  className={`px-6 py-2.5 text-sm font-medium ${isLoading('resetConfig') ? buttonStyles.disabled : buttonStyles.danger}`}
-                >
-                  {isLoading('resetConfig') ? '重置中...' : '确认重置'}
-                </button>
-              </div>
             </div>
-          </div>
-        </div>,
-        document.body
-      )}
+          </div>,
+          document.body
+        )}
     </PageLayout>
   );
 }

--- a/src/app/api/admin/live-stats/route.ts
+++ b/src/app/api/admin/live-stats/route.ts
@@ -1,0 +1,288 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { NextRequest, NextResponse } from 'next/server';
+
+import { getAuthInfoFromCookie } from '@/lib/auth';
+import { getConfig } from '@/lib/config';
+import { db } from '@/lib/db';
+import { LiveStatsResult, LiveViewRecord } from '@/lib/types';
+
+export const runtime = 'nodejs';
+
+export async function GET(request: NextRequest) {
+  const storageType = process.env.NEXT_PUBLIC_STORAGE_TYPE || 'localstorage';
+  if (storageType === 'localstorage') {
+    return NextResponse.json(
+      {
+        error: '不支持本地存储进行直播统计查看',
+      },
+      { status: 400 }
+    );
+  }
+
+  const authInfo = getAuthInfoFromCookie(request);
+  if (!authInfo || !authInfo.username) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const config = await getConfig();
+    const storage = db;
+    const username = authInfo.username;
+
+    // 判定操作者角色
+    if (username !== process.env.USERNAME) {
+      const userEntry = config.UserConfig.Users.find(
+        (u) => u.username === username
+      );
+      if (!userEntry || userEntry.role !== 'admin' || userEntry.banned) {
+        return NextResponse.json({ error: '权限不足' }, { status: 401 });
+      }
+    }
+
+    // 获取所有用户（不限制数量，因为我们会过滤掉没有观看记录的用户）
+    const allUsers = config.UserConfig.Users;
+
+    const userStats: Array<{
+      username: string;
+      totalWatchTime: number;
+      totalViews: number;
+      lastViewTime: number;
+      recentRecords: LiveViewRecord[];
+      avgWatchTime: number;
+      mostWatchedChannel: string;
+      mostWatchedSource: string;
+    }> = [];
+
+    let totalWatchTime = 0;
+    let totalViews = 0;
+    const channelCount: Record<
+      string,
+      { count: number; totalTime: number; channelId: string }
+    > = {};
+    const sourceCount: Record<string, { count: number; sourceKey: string }> =
+      {};
+    const dailyData: Record<string, { watchTime: number; views: number }> = {};
+
+    const now = new Date();
+    const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+    // 为每个用户获取直播观看记录统计（并行查询，提高性能）
+    const userPromises = allUsers.map(async (user) => {
+      try {
+        const userRecordsKey = `live_views:${user.username}`;
+
+        // 添加超时控制，避免 Redis 查询卡住
+        const records: LiveViewRecord[] = await Promise.race([
+          storage.getCache(userRecordsKey),
+          new Promise<null>((resolve) => setTimeout(() => resolve(null), 5000)), // 5秒超时
+        ]).then((result) => result || []);
+
+        if (records.length === 0) {
+          // 跳过没有观看记录的用户，不显示在列表中
+          return null;
+        }
+
+        // 计算用户统计
+        let userWatchTime = 0;
+        let userLastViewTime = 0;
+        const userChannelCount: Record<string, number> = {};
+        const userSourceCount: Record<string, number> = {};
+
+        records.forEach((record) => {
+          // 累计观看时间
+          userWatchTime += record.duration;
+
+          // 更新最后观看时间
+          if (record.endTime > userLastViewTime) {
+            userLastViewTime = record.endTime;
+          }
+
+          // 统计频道
+          const channelKey = `${record.channelName}`;
+          userChannelCount[channelKey] =
+            (userChannelCount[channelKey] || 0) + 1;
+          if (!channelCount[channelKey]) {
+            channelCount[channelKey] = {
+              count: 0,
+              totalTime: 0,
+              channelId: record.channelId,
+            };
+          }
+          channelCount[channelKey].count += 1;
+          channelCount[channelKey].totalTime += record.duration;
+
+          // 统计来源
+          const sourceKey = record.sourceName;
+          userSourceCount[sourceKey] = (userSourceCount[sourceKey] || 0) + 1;
+          if (!sourceCount[sourceKey]) {
+            sourceCount[sourceKey] = { count: 0, sourceKey: record.sourceKey };
+          }
+          sourceCount[sourceKey].count += 1;
+
+          // 统计近7天数据
+          const recordDate = new Date(record.endTime);
+          if (recordDate >= sevenDaysAgo) {
+            const dateKey = recordDate.toISOString().split('T')[0];
+            if (!dailyData[dateKey]) {
+              dailyData[dateKey] = { watchTime: 0, views: 0 };
+            }
+            dailyData[dateKey].watchTime += record.duration;
+            dailyData[dateKey].views += 1;
+          }
+        });
+
+        // 获取最近观看记录（按时间倒序，最多10条）
+        const recentRecords = records
+          .sort((a, b) => b.endTime - a.endTime)
+          .slice(0, 10);
+
+        // 找出最常观看的频道
+        let mostWatchedChannel = '';
+        let maxChannelCount = 0;
+        for (const [channel, count] of Object.entries(userChannelCount)) {
+          if (count > maxChannelCount) {
+            maxChannelCount = count;
+            mostWatchedChannel = channel;
+          }
+        }
+
+        // 找出最常使用的直播源
+        let mostWatchedSource = '';
+        let maxSourceCount = 0;
+        for (const [source, count] of Object.entries(userSourceCount)) {
+          if (count > maxSourceCount) {
+            maxSourceCount = count;
+            mostWatchedSource = source;
+          }
+        }
+
+        const userStat = {
+          username: user.username,
+          totalWatchTime: userWatchTime,
+          totalViews: records.length,
+          lastViewTime: userLastViewTime,
+          recentRecords,
+          avgWatchTime: records.length > 0 ? userWatchTime / records.length : 0,
+          mostWatchedChannel,
+          mostWatchedSource,
+        };
+
+        return userStat;
+      } catch {
+        return null;
+      }
+    });
+
+    // 等待所有用户查询完成
+    const results = await Promise.all(userPromises);
+
+    // 过滤掉 null 结果并收集统计数据
+    for (const result of results) {
+      if (result) {
+        userStats.push(result);
+        totalWatchTime += result.totalWatchTime;
+        totalViews += result.totalViews;
+
+        // 收集频道和来源统计
+        result.recentRecords.forEach((record) => {
+          const channelKey = record.channelName;
+          if (!channelCount[channelKey]) {
+            channelCount[channelKey] = {
+              count: 0,
+              totalTime: 0,
+              channelId: record.channelId,
+            };
+          }
+          channelCount[channelKey].count += 1;
+          channelCount[channelKey].totalTime += record.duration;
+
+          const sourceKey = record.sourceName;
+          if (!sourceCount[sourceKey]) {
+            sourceCount[sourceKey] = { count: 0, sourceKey: record.sourceKey };
+          }
+          sourceCount[sourceKey].count += 1;
+
+          // 统计近7天数据
+          const recordDate = new Date(record.endTime);
+          if (recordDate >= sevenDaysAgo) {
+            const dateKey = recordDate.toISOString().split('T')[0];
+            if (!dailyData[dateKey]) {
+              dailyData[dateKey] = { watchTime: 0, views: 0 };
+            }
+            dailyData[dateKey].watchTime += record.duration;
+            dailyData[dateKey].views += 1;
+          }
+        });
+      }
+    }
+
+    // 按观看时间降序排序
+    userStats.sort((a, b) => b.totalWatchTime - a.totalWatchTime);
+
+    // 整理热门频道数据（取前10个）
+    const topChannels = Object.entries(channelCount)
+      .sort(([, a], [, b]) => b.count - a.count)
+      .slice(0, 10)
+      .map(([channelName, data]) => ({
+        channelName,
+        channelId: data.channelId,
+        viewCount: data.count,
+        totalWatchTime: data.totalTime,
+      }));
+
+    // 整理热门来源数据（取前5个）
+    const topSources = Object.entries(sourceCount)
+      .sort(([, a], [, b]) => b.count - a.count)
+      .slice(0, 5)
+      .map(([sourceName, data]) => ({
+        sourceName,
+        sourceKey: data.sourceKey,
+        viewCount: data.count,
+      }));
+
+    // 整理近7天数据
+    const dailyStats: Array<{
+      date: string;
+      watchTime: number;
+      views: number;
+    }> = [];
+    for (let i = 6; i >= 0; i--) {
+      const date = new Date(now.getTime() - i * 24 * 60 * 60 * 1000);
+      const dateKey = date.toISOString().split('T')[0];
+      const data = dailyData[dateKey] || { watchTime: 0, views: 0 };
+      dailyStats.push({
+        date: dateKey,
+        watchTime: data.watchTime,
+        views: data.views,
+      });
+    }
+
+    const result: LiveStatsResult = {
+      totalUsers: allUsers.length,
+      totalWatchTime,
+      totalViews,
+      avgWatchTimePerUser:
+        allUsers.length > 0 ? totalWatchTime / allUsers.length : 0,
+      avgViewsPerUser: allUsers.length > 0 ? totalViews / allUsers.length : 0,
+      userStats,
+      topChannels,
+      topSources,
+      dailyStats,
+    };
+
+    return NextResponse.json(result, {
+      headers: {
+        'Cache-Control': 'no-store',
+      },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: '获取直播统计失败',
+        details: (error as Error).message,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/live/record/route.ts
+++ b/src/app/api/live/record/route.ts
@@ -1,0 +1,103 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { NextRequest, NextResponse } from 'next/server';
+
+import { getAuthInfoFromCookie } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { LiveViewRecord } from '@/lib/types';
+
+export const runtime = 'nodejs';
+
+export async function POST(request: NextRequest) {
+  const storageType = process.env.NEXT_PUBLIC_STORAGE_TYPE || 'localstorage';
+  if (storageType === 'localstorage') {
+    return NextResponse.json(
+      {
+        error: '不支持本地存储进行直播统计',
+      },
+      { status: 400 }
+    );
+  }
+
+  const authInfo = getAuthInfoFromCookie(request);
+  if (!authInfo || !authInfo.username) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json();
+    const {
+      channelName,
+      channelId,
+      sourceName,
+      sourceKey,
+      startTime,
+      endTime,
+      channelGroup,
+      channelLogo,
+    } = body;
+
+    // 验证必填字段
+    if (
+      !channelName ||
+      !channelId ||
+      !sourceName ||
+      !sourceKey ||
+      !startTime ||
+      !endTime
+    ) {
+      return NextResponse.json({ error: '缺少必填字段' }, { status: 400 });
+    }
+
+    // 计算观看时长
+    const duration = Math.floor((endTime - startTime) / 1000); // 转换为秒
+
+    // 只记录观看时长大于5秒的记录
+    if (duration < 5) {
+      return NextResponse.json({
+        success: true,
+        message: '观看时长过短，不记录',
+      });
+    }
+
+    const record: LiveViewRecord = {
+      username: authInfo.username,
+      channelName,
+      channelId,
+      sourceName,
+      sourceKey,
+      startTime,
+      endTime,
+      duration,
+      channelGroup,
+      channelLogo,
+    };
+
+    // 保存到数据库
+    const storage = db;
+    const key = `live_view_${authInfo.username}_${Date.now()}`;
+    await storage.setCache(key, record);
+
+    // 同时保存到用户的直播观看记录列表
+    const userRecordsKey = `live_views:${authInfo.username}`;
+    const existingRecords = (await storage.getCache(userRecordsKey)) || [];
+    existingRecords.push(record);
+
+    // 只保留最近100条记录
+    if (existingRecords.length > 100) {
+      existingRecords.splice(0, existingRecords.length - 100);
+    }
+
+    await storage.setCache(userRecordsKey, existingRecords);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: '记录直播观看失败',
+        details: (error as Error).message,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/live/page.tsx
+++ b/src/app/live/page.tsx
@@ -2,21 +2,12 @@
 
 'use client';
 
-import { Suspense, useEffect, useRef, useState } from 'react';
-
 import Hls from 'hls.js';
 import { Heart, Radio, RefreshCw, Search, Tv, X } from 'lucide-react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { Suspense, useEffect, useRef, useState } from 'react';
 
-import {
-  debounce,
-} from '@/lib/channel-search';
-import {
-  isMobile,
-  isTablet, 
-  isSafari,
-  devicePerformance
-} from '@/lib/utils';
+import { debounce } from '@/lib/channel-search';
 import {
   deleteFavorite,
   generateStorageKey,
@@ -25,6 +16,7 @@ import {
   subscribeToDataUpdates,
 } from '@/lib/db.client';
 import { parseCustomTimeFormat } from '@/lib/time';
+import { devicePerformance, isMobile, isSafari } from '@/lib/utils';
 
 import EpgScrollableRow from '@/components/EpgScrollableRow';
 import PageLayout from '@/components/PageLayout';
@@ -50,7 +42,7 @@ interface LiveChannel {
 interface LiveSource {
   key: string;
   name: string;
-  url: string;  // m3u 地址
+  url: string; // m3u 地址
   ua?: string;
   epg?: string; // 节目单
   from: 'config' | 'custom';
@@ -82,7 +74,9 @@ function LivePageClient() {
 
   // 频道相关
   const [currentChannels, setCurrentChannels] = useState<LiveChannel[]>([]);
-  const [currentChannel, setCurrentChannel] = useState<LiveChannel | null>(null);
+  const [currentChannel, setCurrentChannel] = useState<LiveChannel | null>(
+    null
+  );
   useEffect(() => {
     currentChannelRef.current = currentChannel;
   }, [currentChannel]);
@@ -97,7 +91,7 @@ function LivePageClient() {
 
   // 切换直播源状态
   const [isSwitchingSource, setIsSwitchingSource] = useState(false);
-  
+
   // 刷新相关状态
   const [isRefreshingSource, setIsRefreshingSource] = useState(false);
   const [autoRefreshEnabled, setAutoRefreshEnabled] = useState(() => {
@@ -117,11 +111,15 @@ function LivePageClient() {
   const autoRefreshTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   // 分组相关
-  const [groupedChannels, setGroupedChannels] = useState<{ [key: string]: LiveChannel[] }>({});
+  const [groupedChannels, setGroupedChannels] = useState<{
+    [key: string]: LiveChannel[];
+  }>({});
   const [selectedGroup, setSelectedGroup] = useState<string>('');
 
   // Tab 切换
-  const [activeTab, setActiveTab] = useState<'channels' | 'sources'>('channels');
+  const [activeTab, setActiveTab] = useState<'channels' | 'sources'>(
+    'channels'
+  );
 
   // 频道列表收起状态
   const [isChannelListCollapsed, setIsChannelListCollapsed] = useState(false);
@@ -131,7 +129,9 @@ function LivePageClient() {
 
   // 搜索相关状态
   const [searchQuery, setSearchQuery] = useState('');
-  const [currentSourceSearchResults, setCurrentSourceSearchResults] = useState<LiveChannel[]>([]);
+  const [currentSourceSearchResults, setCurrentSourceSearchResults] = useState<
+    LiveChannel[]
+  >([]);
 
   // 直播源搜索状态
   const [sourceSearchQuery, setSourceSearchQuery] = useState('');
@@ -163,22 +163,40 @@ function LivePageClient() {
   const [enableDvrMode, setEnableDvrMode] = useState(false); // 用户手动启用DVR模式
 
   // EPG数据清洗函数 - 去除重叠的节目，保留时间较短的，只显示今日节目
-  const cleanEpgData = (programs: Array<{ start: string; end: string; title: string }>) => {
+  const cleanEpgData = (
+    programs: Array<{ start: string; end: string; title: string }>
+  ) => {
     if (!programs || programs.length === 0) return programs;
 
     // 获取今日日期（只考虑年月日，忽略时间）
     const today = new Date();
-    const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-    const todayEnd = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1);
+    const todayStart = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate()
+    );
+    const todayEnd = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate() + 1
+    );
 
     // 首先过滤出今日的节目（包括跨天节目）
-    const todayPrograms = programs.filter(program => {
+    const todayPrograms = programs.filter((program) => {
       const programStart = parseCustomTimeFormat(program.start);
       const programEnd = parseCustomTimeFormat(program.end);
 
       // 获取节目的日期范围
-      const programStartDate = new Date(programStart.getFullYear(), programStart.getMonth(), programStart.getDate());
-      const programEndDate = new Date(programEnd.getFullYear(), programEnd.getMonth(), programEnd.getDate());
+      const programStartDate = new Date(
+        programStart.getFullYear(),
+        programStart.getMonth(),
+        programStart.getDate()
+      );
+      const programEndDate = new Date(
+        programEnd.getFullYear(),
+        programEnd.getMonth(),
+        programEnd.getDate()
+      );
 
       // 如果节目的开始时间或结束时间在今天，或者节目跨越今天，都算作今天的节目
       return (
@@ -195,7 +213,11 @@ function LivePageClient() {
       return startA - startB;
     });
 
-    const cleanedPrograms: Array<{ start: string; end: string; title: string }> = [];
+    const cleanedPrograms: Array<{
+      start: string;
+      end: string;
+      title: string;
+    }> = [];
 
     for (let i = 0; i < sortedPrograms.length; i++) {
       const currentProgram = sortedPrograms[i];
@@ -237,8 +259,10 @@ function LivePageClient() {
             (currentStart <= existingStart && currentEnd >= existingEnd)
           ) {
             // 计算节目时长
-            const currentDuration = currentEnd.getTime() - currentStart.getTime();
-            const existingDuration = existingEnd.getTime() - existingStart.getTime();
+            const currentDuration =
+              currentEnd.getTime() - currentStart.getTime();
+            const existingDuration =
+              existingEnd.getTime() - existingStart.getTime();
 
             // 如果当前节目时间更短，则替换已存在的节目
             if (currentDuration < existingDuration) {
@@ -262,18 +286,82 @@ function LivePageClient() {
   const groupButtonRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const channelListRef = useRef<HTMLDivElement>(null);
 
+  // 直播观看追踪相关
+  const viewStartTimeRef = useRef<number | null>(null);
+  const currentViewChannelRef = useRef<LiveChannel | null>(null);
+  const currentViewSourceRef = useRef<LiveSource | null>(null);
+
   // -----------------------------------------------------------------------------
   // 工具函数（Utils）
   // -----------------------------------------------------------------------------
 
+  // 记录直播观看
+  const recordLiveView = async () => {
+    if (
+      !viewStartTimeRef.current ||
+      !currentViewChannelRef.current ||
+      !currentViewSourceRef.current
+    ) {
+      return;
+    }
+
+    const endTime = Date.now();
+    const startTime = viewStartTimeRef.current;
+    const duration = endTime - startTime;
+
+    // 只记录观看时长大于5秒的记录
+    if (duration < 5000) {
+      return;
+    }
+
+    try {
+      await fetch('/api/live/record', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          channelName: currentViewChannelRef.current.name,
+          channelId: currentViewChannelRef.current.id,
+          sourceName: currentViewSourceRef.current.name,
+          sourceKey: currentViewSourceRef.current.key,
+          startTime,
+          endTime,
+          channelGroup: currentViewChannelRef.current.group,
+          channelLogo: currentViewChannelRef.current.logo,
+        }),
+      });
+    } catch (error) {
+      console.error('记录直播观看失败:', error);
+    }
+
+    // 重置追踪状态
+    viewStartTimeRef.current = null;
+    currentViewChannelRef.current = null;
+    currentViewSourceRef.current = null;
+  };
+
+  // 开始追踪直播观看
+  const startTrackingView = (channel: LiveChannel, source: LiveSource) => {
+    // 先记录之前的观看
+    if (viewStartTimeRef.current) {
+      recordLiveView();
+    }
+
+    // 开始新的追踪
+    viewStartTimeRef.current = Date.now();
+    currentViewChannelRef.current = channel;
+    currentViewSourceRef.current = source;
+  };
+
   // 刷新直播源
   const refreshLiveSources = async () => {
     if (isRefreshingSource) return;
-    
+
     setIsRefreshingSource(true);
     try {
       console.log('开始刷新直播源...');
-      
+
       // 调用后端刷新API
       const response = await fetch('/api/admin/live/refresh', {
         method: 'POST',
@@ -281,21 +369,20 @@ function LivePageClient() {
           'Content-Type': 'application/json',
         },
       });
-      
+
       if (!response.ok) {
         throw new Error('刷新直播源失败');
       }
-      
+
       const result = await response.json();
       if (!result.success) {
         throw new Error(result.error || '刷新直播源失败');
       }
-      
+
       console.log('直播源刷新成功');
-      
+
       // 重新获取直播源列表
       await fetchLiveSources();
-      
     } catch (error) {
       console.error('刷新直播源失败:', error);
       // 这里可以显示错误提示，但不设置全局error状态
@@ -303,7 +390,7 @@ function LivePageClient() {
       setIsRefreshingSource(false);
     }
   };
-  
+
   // 设置自动刷新
   const setupAutoRefresh = () => {
     // 清除现有定时器
@@ -311,14 +398,14 @@ function LivePageClient() {
       clearInterval(autoRefreshTimerRef.current);
       autoRefreshTimerRef.current = null;
     }
-    
+
     if (autoRefreshEnabled) {
       const intervalMs = autoRefreshInterval * 60 * 1000; // 转换为毫秒
       autoRefreshTimerRef.current = setInterval(() => {
         console.log(`自动刷新直播源 (间隔: ${autoRefreshInterval}分钟)`);
         refreshLiveSources();
       }, intervalMs);
-      
+
       console.log(`自动刷新已启用，间隔: ${autoRefreshInterval}分钟`);
     } else {
       console.log('自动刷新已禁用');
@@ -349,7 +436,9 @@ function LivePageClient() {
         // 默认选中第一个源
         const firstSource = sources[0];
         if (needLoadSource) {
-          const foundSource = sources.find((s: LiveSource) => s.key === needLoadSource);
+          const foundSource = sources.find(
+            (s: LiveSource) => s.key === needLoadSource
+          );
           if (foundSource) {
             setCurrentSource(foundSource);
             await fetchChannels(foundSource);
@@ -412,8 +501,8 @@ function LivePageClient() {
         setFilteredChannels([]);
 
         // 更新直播源的频道数为 0
-        setLiveSources(prevSources =>
-          prevSources.map(s =>
+        setLiveSources((prevSources) =>
+          prevSources.map((s) =>
             s.key === source.key ? { ...s, channelNumber: 0 } : s
           )
         );
@@ -429,14 +518,14 @@ function LivePageClient() {
         name: channel.name,
         logo: channel.logo,
         group: channel.group || '其他',
-        url: channel.url
+        url: channel.url,
       }));
 
       setCurrentChannels(channels);
 
       // 更新直播源的频道数
-      setLiveSources(prevSources =>
-        prevSources.map(s =>
+      setLiveSources((prevSources) =>
+        prevSources.map((s) =>
           s.key === source.key ? { ...s, channelNumber: channels.length } : s
         )
       );
@@ -444,7 +533,9 @@ function LivePageClient() {
       // 默认选中第一个频道
       if (channels.length > 0) {
         if (needLoadChannel) {
-          const foundChannel = channels.find((c: LiveChannel) => c.id === needLoadChannel);
+          const foundChannel = channels.find(
+            (c: LiveChannel) => c.id === needLoadChannel
+          );
           if (foundChannel) {
             setCurrentChannel(foundChannel);
             setVideoUrl(foundChannel.url);
@@ -477,7 +568,9 @@ function LivePageClient() {
       // 默认选中当前加载的channel所在的分组，如果没有则选中第一个分组
       let targetGroup = '';
       if (needLoadChannel) {
-        const foundChannel = channels.find((c: LiveChannel) => c.id === needLoadChannel);
+        const foundChannel = channels.find(
+          (c: LiveChannel) => c.id === needLoadChannel
+        );
         if (foundChannel) {
           targetGroup = foundChannel.group || '其他';
         }
@@ -511,8 +604,8 @@ function LivePageClient() {
       setFilteredChannels([]);
 
       // 更新直播源的频道数为 0
-      setLiveSources(prevSources =>
-        prevSources.map(s =>
+      setLiveSources((prevSources) =>
+        prevSources.map((s) =>
           s.key === source.key ? { ...s, channelNumber: 0 } : s
         )
       );
@@ -567,6 +660,11 @@ function LivePageClient() {
     setCurrentChannel(channel);
     setVideoUrl(channel.url);
 
+    // 开始追踪新频道的观看
+    if (currentSource) {
+      startTrackingView(channel, currentSource);
+    }
+
     // 自动滚动到选中的频道位置
     setTimeout(() => {
       scrollToChannel(channel);
@@ -576,14 +674,16 @@ function LivePageClient() {
     if (channel.tvgId && currentSource) {
       try {
         setIsEpgLoading(true); // 开始加载 EPG 数据
-        const response = await fetch(`/api/live/epg?source=${currentSource.key}&tvgId=${channel.tvgId}`);
+        const response = await fetch(
+          `/api/live/epg?source=${currentSource.key}&tvgId=${channel.tvgId}`
+        );
         if (response.ok) {
           const result = await response.json();
           if (result.success) {
             // 清洗EPG数据，去除重叠的节目
             const cleanedData = {
               ...result.data,
-              programs: cleanEpgData(result.data.programs)
+              programs: cleanEpgData(result.data.programs),
             };
             setEpgData(cleanedData);
           }
@@ -605,7 +705,9 @@ function LivePageClient() {
     if (!channelListRef.current) return;
 
     // 使用 data 属性来查找频道元素
-    const targetElement = channelListRef.current.querySelector(`[data-channel-id="${channel.id}"]`) as HTMLButtonElement;
+    const targetElement = channelListRef.current.querySelector(
+      `[data-channel-id="${channel.id}"]`
+    ) as HTMLButtonElement;
 
     if (targetElement) {
       // 计算滚动位置，使频道居中显示
@@ -614,12 +716,16 @@ function LivePageClient() {
       const elementRect = targetElement.getBoundingClientRect();
 
       // 计算目标滚动位置
-      const scrollTop = container.scrollTop + (elementRect.top - containerRect.top) - (containerRect.height / 2) + (elementRect.height / 2);
+      const scrollTop =
+        container.scrollTop +
+        (elementRect.top - containerRect.top) -
+        containerRect.height / 2 +
+        elementRect.height / 2;
 
       // 平滑滚动到目标位置
       container.scrollTo({
         top: Math.max(0, scrollTop),
-        behavior: 'smooth'
+        behavior: 'smooth',
       });
     }
   };
@@ -638,7 +744,9 @@ function LivePageClient() {
     }
 
     // 直接通过 data-group 属性查找目标按钮
-    const targetButton = groupContainerRef.current.querySelector(`[data-group="${group}"]`) as HTMLButtonElement;
+    const targetButton = groupContainerRef.current.querySelector(
+      `[data-group="${group}"]`
+    ) as HTMLButtonElement;
 
     if (targetButton) {
       // 手动设置分组状态，确保状态一致性
@@ -732,11 +840,16 @@ function LivePageClient() {
     if (isSwitchingSource) return;
 
     setSelectedGroup(group);
-    const filtered = currentChannels.filter(channel => channel.group === group);
+    const filtered = currentChannels.filter(
+      (channel) => channel.group === group
+    );
     setFilteredChannels(filtered);
 
     // 如果当前选中的频道在新的分组中，自动滚动到该频道位置
-    if (currentChannel && filtered.some(channel => channel.id === currentChannel.id)) {
+    if (
+      currentChannel &&
+      filtered.some((channel) => channel.id === currentChannel.id)
+    ) {
       setTimeout(() => {
         scrollToChannel(currentChannel);
       }, 100);
@@ -745,7 +858,7 @@ function LivePageClient() {
       if (channelListRef.current) {
         channelListRef.current.scrollTo({
           top: 0,
-          behavior: 'smooth'
+          behavior: 'smooth',
         });
       }
     }
@@ -759,9 +872,10 @@ function LivePageClient() {
     }
 
     const normalizedQuery = query.toLowerCase();
-    const results = currentChannels.filter(channel =>
-      channel.name.toLowerCase().includes(normalizedQuery) ||
-      channel.group.toLowerCase().includes(normalizedQuery)
+    const results = currentChannels.filter(
+      (channel) =>
+        channel.name.toLowerCase().includes(normalizedQuery) ||
+        channel.group.toLowerCase().includes(normalizedQuery)
     );
     setCurrentSourceSearchResults(results);
   };
@@ -783,9 +897,10 @@ function LivePageClient() {
     }
 
     const normalizedQuery = query.toLowerCase();
-    const results = liveSources.filter(source =>
-      source.name.toLowerCase().includes(normalizedQuery) ||
-      source.key.toLowerCase().includes(normalizedQuery)
+    const results = liveSources.filter(
+      (source) =>
+        source.name.toLowerCase().includes(normalizedQuery) ||
+        source.key.toLowerCase().includes(normalizedQuery)
     );
     setFilteredSources(results);
   };
@@ -815,19 +930,28 @@ function LivePageClient() {
       try {
         if (newFavorited) {
           // 如果未收藏，添加收藏
-          await saveFavorite(`live_${currentSourceRef.current.key}`, `live_${currentChannelRef.current.id}`, {
-            title: currentChannelRef.current.name,
-            source_name: currentSourceRef.current.name,
-            year: '',
-            cover: `/api/proxy/logo?url=${encodeURIComponent(currentChannelRef.current.logo)}&source=${currentSourceRef.current.key}`,
-            total_episodes: 1,
-            save_time: Date.now(),
-            search_title: '',
-            origin: 'live',
-          });
+          await saveFavorite(
+            `live_${currentSourceRef.current.key}`,
+            `live_${currentChannelRef.current.id}`,
+            {
+              title: currentChannelRef.current.name,
+              source_name: currentSourceRef.current.name,
+              year: '',
+              cover: `/api/proxy/logo?url=${encodeURIComponent(
+                currentChannelRef.current.logo
+              )}&source=${currentSourceRef.current.key}`,
+              total_episodes: 1,
+              save_time: Date.now(),
+              search_title: '',
+              origin: 'live',
+            }
+          );
         } else {
           // 如果已收藏，删除收藏
-          await deleteFavorite(`live_${currentSourceRef.current.key}`, `live_${currentChannelRef.current.id}`);
+          await deleteFavorite(
+            `live_${currentSourceRef.current.key}`,
+            `live_${currentChannelRef.current.id}`
+          );
         }
       } catch (err) {
         console.error('收藏操作失败:', err);
@@ -843,6 +967,34 @@ function LivePageClient() {
   // 初始化
   useEffect(() => {
     fetchLiveSources();
+  }, []);
+
+  // 页面卸载时记录观看
+  useEffect(() => {
+    return () => {
+      // 组件卸载时记录观看
+      if (viewStartTimeRef.current) {
+        recordLiveView();
+      }
+    };
+  }, []);
+
+  // 监听页面可见性变化，记录观看
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        // 页面隐藏时记录观看
+        if (viewStartTimeRef.current) {
+          recordLiveView();
+        }
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
   }, []);
 
   // 只在用户开始搜索时才加载跨源数据，而不是页面加载时就加载
@@ -866,7 +1018,10 @@ function LivePageClient() {
     if (!currentSource || !currentChannel) return;
     (async () => {
       try {
-        const fav = await checkIsFavorited(`live_${currentSource.key}`, `live_${currentChannel.id}`);
+        const fav = await checkIsFavorited(
+          `live_${currentSource.key}`,
+          `live_${currentChannel.id}`
+        );
         setFavorited(fav);
         favoritedRef.current = fav;
       } catch (err) {
@@ -882,7 +1037,10 @@ function LivePageClient() {
     const unsubscribe = subscribeToDataUpdates(
       'favoritesUpdated',
       (favorites: Record<string, any>) => {
-        const key = generateStorageKey(`live_${currentSource.key}`, `live_${currentChannel.id}`);
+        const key = generateStorageKey(
+          `live_${currentSource.key}`,
+          `live_${currentChannel.id}`
+        );
         const isFav = !!favorites[key];
         setFavorited(isFav);
         favoritedRef.current = isFav;
@@ -895,7 +1053,7 @@ function LivePageClient() {
   // 监听自动刷新设置变化
   useEffect(() => {
     setupAutoRefresh();
-    
+
     // 清理函数
     return () => {
       if (autoRefreshTimerRef.current) {
@@ -908,13 +1066,19 @@ function LivePageClient() {
   // 保存自动刷新配置到localStorage
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      localStorage.setItem('live-auto-refresh-enabled', JSON.stringify(autoRefreshEnabled));
+      localStorage.setItem(
+        'live-auto-refresh-enabled',
+        JSON.stringify(autoRefreshEnabled)
+      );
     }
   }, [autoRefreshEnabled]);
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      localStorage.setItem('live-auto-refresh-interval', autoRefreshInterval.toString());
+      localStorage.setItem(
+        'live-auto-refresh-interval',
+        autoRefreshInterval.toString()
+      );
     }
   }, [autoRefreshInterval]);
 
@@ -958,7 +1122,10 @@ function LivePageClient() {
         // 所有的请求都带一个 source 参数
         try {
           const url = new URL(context.url);
-          url.searchParams.set('moontv-source', currentSourceRef.current?.key || '');
+          url.searchParams.set(
+            'moontv-source',
+            currentSourceRef.current?.key || ''
+          );
           context.url = url.toString();
         } catch (error) {
           // ignore
@@ -969,7 +1136,8 @@ function LivePageClient() {
           (context as any).type === 'level'
         ) {
           // 判断是否浏览器直连
-          const isLiveDirectConnectStr = localStorage.getItem('liveDirectConnect');
+          const isLiveDirectConnectStr =
+            localStorage.getItem('liveDirectConnect');
           const isLiveDirectConnect = isLiveDirectConnectStr === 'true';
           if (isLiveDirectConnect) {
             // 浏览器直连，使用 URL 对象处理参数
@@ -1014,44 +1182,56 @@ function LivePageClient() {
     // 基于最新 hls.js 源码和设备性能的智能配置
     const hlsConfig = {
       debug: false,
-      
+
       // Worker 配置 - 根据设备性能和浏览器能力
       enableWorker: !isMobile && !isSafari && devicePerformance !== 'low',
-      
+
       // 低延迟模式 - 仅在高性能非移动设备上启用 (源码默认为true)
       lowLatencyMode: !isMobile && devicePerformance === 'high',
-      
+
       // 缓冲管理优化 - 参考 hls.js 源码默认值进行设备优化
       backBufferLength: devicePerformance === 'low' ? 30 : Infinity, // 源码默认 Infinity
-      maxBufferLength: devicePerformance === 'low' ? 20 :
-                      devicePerformance === 'medium' ? 30 : 30, // 源码默认 30
-      maxBufferSize: devicePerformance === 'low' ? 30 * 1000 * 1000 :
-                    devicePerformance === 'medium' ? 60 * 1000 * 1000 : 60 * 1000 * 1000, // 源码默认 60MB
+      maxBufferLength:
+        devicePerformance === 'low'
+          ? 20
+          : devicePerformance === 'medium'
+          ? 30
+          : 30, // 源码默认 30
+      maxBufferSize:
+        devicePerformance === 'low'
+          ? 30 * 1000 * 1000
+          : devicePerformance === 'medium'
+          ? 60 * 1000 * 1000
+          : 60 * 1000 * 1000, // 源码默认 60MB
       maxBufferHole: 0.1, // 源码默认值，允许小的缓冲区空洞
-      
+
       // Gap Controller 配置 - 缓冲区空洞处理 (源码中的默认值)
-      nudgeOffset: 0.1,   // 跳过小间隙的偏移量
-      nudgeMaxRetry: 3,   // 最大重试次数 (源码默认)
-      
+      nudgeOffset: 0.1, // 跳过小间隙的偏移量
+      nudgeMaxRetry: 3, // 最大重试次数 (源码默认)
+
       // 自适应比特率优化 - 参考源码默认值
-      abrEwmaDefaultEstimate: devicePerformance === 'low' ? 500000 :
-                             devicePerformance === 'medium' ? 500000 : 500000, // 源码默认 500k
+      abrEwmaDefaultEstimate:
+        devicePerformance === 'low'
+          ? 500000
+          : devicePerformance === 'medium'
+          ? 500000
+          : 500000, // 源码默认 500k
       abrBandWidthFactor: 0.95, // 源码默认
       abrBandWidthUpFactor: 0.7, // 源码默认
       abrMaxWithRealBitrate: false, // 源码默认
       maxStarvationDelay: 4, // 源码默认
       maxLoadingDelay: 4, // 源码默认
-      
+
       // 直播流特殊配置
       startLevel: undefined, // 源码默认，自动选择起始质量
       capLevelToPlayerSize: false, // 源码默认
-      
+
       // 渐进式加载 (直播流建议关闭)
       progressive: false,
-      
+
       // 浏览器特殊优化
       liveDurationInfinity: false, // 源码默认，Safari兼容
-      
+
       // 移动设备网络优化 - 使用新的LoadPolicy配置
       ...(isMobile && {
         // 使用 fragLoadPolicy 替代旧的配置方式
@@ -1063,18 +1243,18 @@ function LivePageClient() {
               maxNumRetry: 2,
               retryDelayMs: 1000,
               maxRetryDelayMs: 8000,
-              backoff: 'linear' as const
+              backoff: 'linear' as const,
             },
             errorRetry: {
               maxNumRetry: 3,
               retryDelayMs: 1000,
               maxRetryDelayMs: 8000,
-              backoff: 'linear' as const
-            }
-          }
-        }
+              backoff: 'linear' as const,
+            },
+          },
+        },
       }),
-      
+
       loader: CustomHlsJsLoader,
     };
 
@@ -1090,26 +1270,30 @@ function LivePageClient() {
       // 使用最新版本的错误详情类型
       if (data.details === Hls.ErrorDetails.KEY_LOAD_ERROR) {
         const currentTime = Date.now();
-        
+
         // 重置计数器（如果距离上次错误超过10秒）
         if (currentTime - lastErrorTime > ERROR_TIMEOUT) {
           keyLoadErrorCount = 0;
         }
-        
+
         keyLoadErrorCount++;
         lastErrorTime = currentTime;
-        
-        console.warn(`KeyLoadError count: ${keyLoadErrorCount}/${MAX_KEY_ERRORS}`);
-        
+
+        console.warn(
+          `KeyLoadError count: ${keyLoadErrorCount}/${MAX_KEY_ERRORS}`
+        );
+
         // 如果短时间内keyLoadError次数过多，认为这个频道不可用
         if (keyLoadErrorCount >= MAX_KEY_ERRORS) {
-          console.error('Too many keyLoadErrors, marking channel as unavailable');
+          console.error(
+            'Too many keyLoadErrors, marking channel as unavailable'
+          );
           setUnsupportedType('channel-unavailable');
           setIsVideoLoading(false);
           hls.destroy();
           return;
         }
-        
+
         // 使用指数退避重试策略
         if (keyLoadErrorCount <= 2) {
           setTimeout(() => {
@@ -1136,9 +1320,12 @@ function LivePageClient() {
       }
 
       // v1.6.13 增强：处理直播中的时间戳错误（直播回搜修复）
-      if (data.details === Hls.ErrorDetails.BUFFER_APPEND_ERROR &&
-          data.err && data.err.message &&
-          data.err.message.includes('timestamp')) {
+      if (
+        data.details === Hls.ErrorDetails.BUFFER_APPEND_ERROR &&
+        data.err &&
+        data.err.message &&
+        data.err.message.includes('timestamp')
+      ) {
         console.log('直播时间戳错误，利用v1.6.13修复重新加载...');
         try {
           // 对于直播，直接重新开始加载最新片段
@@ -1164,7 +1351,7 @@ function LivePageClient() {
         switch (data.type) {
           case Hls.ErrorTypes.NETWORK_ERROR:
             console.log('Network error, attempting to recover...');
-            
+
             // 根据具体的网络错误类型进行处理
             if (data.details === Hls.ErrorDetails.MANIFEST_LOAD_ERROR) {
               console.log('Manifest load error, attempting reload...');
@@ -1183,13 +1370,16 @@ function LivePageClient() {
               }
             }
             break;
-            
+
           case Hls.ErrorTypes.MEDIA_ERROR:
             console.log('Media error, attempting to recover...');
             try {
               hls.recoverMediaError();
             } catch (e) {
-              console.error('Failed to recover from media error, trying audio codec swap:', e);
+              console.error(
+                'Failed to recover from media error, trying audio codec swap:',
+                e
+              );
               try {
                 // 使用音频编解码器交换作为备选方案
                 hls.swapAudioCodec();
@@ -1201,7 +1391,7 @@ function LivePageClient() {
               }
             }
             break;
-            
+
           default:
             console.log('Fatal error, destroying HLS instance');
             setUnsupportedType('fatal-error');
@@ -1214,13 +1404,22 @@ function LivePageClient() {
 
     // 添加性能监控和缓冲管理事件
     hls.on(Hls.Events.FRAG_LOADED, (event, data) => {
-      if (data.frag.stats && data.frag.stats.loading && data.frag.stats.loaded) {
-        const loadTime = data.frag.stats.loading.end - data.frag.stats.loading.start;
+      if (
+        data.frag.stats &&
+        data.frag.stats.loading &&
+        data.frag.stats.loaded
+      ) {
+        const loadTime =
+          data.frag.stats.loading.end - data.frag.stats.loading.start;
         if (loadTime > 0 && data.frag.stats.loaded > 0) {
           const throughputBps = (data.frag.stats.loaded * 8 * 1000) / loadTime; // bits per second
           const throughputMbps = throughputBps / 1000000;
           if (process.env.NODE_ENV === 'development') {
-            console.log(`Fragment loaded: ${loadTime.toFixed(2)}ms, size: ${data.frag.stats.loaded}B, throughput: ${throughputMbps.toFixed(2)} Mbps`);
+            console.log(
+              `Fragment loaded: ${loadTime.toFixed(2)}ms, size: ${
+                data.frag.stats.loaded
+              }B, throughput: ${throughputMbps.toFixed(2)} Mbps`
+            );
           }
         }
       }
@@ -1230,9 +1429,13 @@ function LivePageClient() {
     // v1.6.15 改进：HLS.js 内部已优化 buffer stall 和 gap segment 处理
     hls.on(Hls.Events.ERROR, (event, data) => {
       if (data.details === Hls.ErrorDetails.BUFFER_STALLED_ERROR) {
-        console.warn('[HLS v1.6.15] Buffer stalled - internal recovery improved');
+        console.warn(
+          '[HLS v1.6.15] Buffer stalled - internal recovery improved'
+        );
       } else if (data.details === Hls.ErrorDetails.BUFFER_SEEK_OVER_HOLE) {
-        console.warn('[HLS v1.6.15] Buffer gap detected - internal handling improved');
+        console.warn(
+          '[HLS v1.6.15] Buffer gap detected - internal handling improved'
+        );
       }
     });
 
@@ -1253,12 +1456,7 @@ function LivePageClient() {
   useEffect(() => {
     // 异步初始化播放器，避免SSR问题
     const initPlayer = async () => {
-      if (
-        !Hls ||
-        !videoUrl ||
-        !artRef.current ||
-        !currentChannel
-      ) {
+      if (!Hls || !videoUrl || !artRef.current || !currentChannel) {
         return;
       }
 
@@ -1271,12 +1469,14 @@ function LivePageClient() {
 
       // 根据hls.js源码设计，直接让hls.js处理各种媒体类型和错误
       // 不需要预检查，hls.js会在加载时自动检测和处理
-      
+
       // 重置不支持的类型
       setUnsupportedType(null);
 
       const customType = { m3u8: m3u8Loader };
-      const targetUrl = `/api/proxy/m3u8?url=${encodeURIComponent(videoUrl)}&moontv-source=${currentSourceRef.current?.key || ''}`;
+      const targetUrl = `/api/proxy/m3u8?url=${encodeURIComponent(
+        videoUrl
+      )}&moontv-source=${currentSourceRef.current?.key || ''}`;
       try {
         // 使用动态导入的 Artplayer
         const Artplayer = (window as any).DynamicArtplayer;
@@ -1347,11 +1547,19 @@ function LivePageClient() {
 
                     // 如果可拖动范围大于60秒，说明支持回放
                     if (seekableRange > 60) {
-                      console.log('✓ 检测到支持回放，可拖动范围:', Math.floor(seekableRange), '秒');
+                      console.log(
+                        '✓ 检测到支持回放，可拖动范围:',
+                        Math.floor(seekableRange),
+                        '秒'
+                      );
                       setDvrDetected(true);
                       setDvrSeekableRange(Math.floor(seekableRange));
                     } else {
-                      console.log('✗ 纯直播流，可拖动范围:', Math.floor(seekableRange), '秒');
+                      console.log(
+                        '✗ 纯直播流，可拖动范围:',
+                        Math.floor(seekableRange),
+                        '秒'
+                      );
                       setDvrDetected(false);
                     }
                   }
@@ -1389,7 +1597,6 @@ function LivePageClient() {
             targetUrl
           );
         }
-
       } catch (err) {
         console.error('创建播放器失败:', err);
         // 不设置错误，只记录日志
@@ -1400,10 +1607,10 @@ function LivePageClient() {
     const loadAndInit = async () => {
       try {
         const { default: Artplayer } = await import('artplayer');
-        
+
         // 将导入的模块设置为全局变量供 initPlayer 使用
         (window as any).DynamicArtplayer = Artplayer;
-        
+
         await initPlayer();
       } catch (error) {
         console.error('动态导入 ArtPlayer 失败:', error);
@@ -1523,16 +1730,25 @@ function LivePageClient() {
             <div className='mb-6 w-80 mx-auto'>
               <div className='flex justify-center space-x-2 mb-4'>
                 <div
-                  className={`w-3 h-3 rounded-full transition-all duration-500 ${loadingStage === 'loading' ? 'bg-green-500 scale-125' : 'bg-green-500'
-                    }`}
+                  className={`w-3 h-3 rounded-full transition-all duration-500 ${
+                    loadingStage === 'loading'
+                      ? 'bg-green-500 scale-125'
+                      : 'bg-green-500'
+                  }`}
                 ></div>
                 <div
-                  className={`w-3 h-3 rounded-full transition-all duration-500 ${loadingStage === 'fetching' ? 'bg-green-500 scale-125' : 'bg-green-500'
-                    }`}
+                  className={`w-3 h-3 rounded-full transition-all duration-500 ${
+                    loadingStage === 'fetching'
+                      ? 'bg-green-500 scale-125'
+                      : 'bg-green-500'
+                  }`}
                 ></div>
                 <div
-                  className={`w-3 h-3 rounded-full transition-all duration-500 ${loadingStage === 'ready' ? 'bg-green-500 scale-125' : 'bg-gray-300'
-                    }`}
+                  className={`w-3 h-3 rounded-full transition-all duration-500 ${
+                    loadingStage === 'ready'
+                      ? 'bg-green-500 scale-125'
+                      : 'bg-gray-300'
+                  }`}
                 ></div>
               </div>
 
@@ -1542,7 +1758,11 @@ function LivePageClient() {
                   className='h-full bg-gradient-to-r from-green-500 to-emerald-600 rounded-full transition-all duration-1000 ease-out'
                   style={{
                     width:
-                      loadingStage === 'loading' ? '33%' : loadingStage === 'fetching' ? '66%' : '100%',
+                      loadingStage === 'loading'
+                        ? '33%'
+                        : loadingStage === 'fetching'
+                        ? '66%'
+                        : '100%',
                   }}
                 ></div>
               </div>
@@ -1634,17 +1854,14 @@ function LivePageClient() {
           {/* 折叠控制 - 仅在 lg 及以上屏幕显示 */}
           <div className='hidden lg:flex justify-end'>
             <button
-              onClick={() =>
-                setIsChannelListCollapsed(!isChannelListCollapsed)
-              }
+              onClick={() => setIsChannelListCollapsed(!isChannelListCollapsed)}
               className='group relative flex items-center space-x-1.5 px-3 py-1.5 rounded-full bg-white/80 hover:bg-white dark:bg-gray-800/80 dark:hover:bg-gray-800 backdrop-blur-sm border border-gray-200/50 dark:border-gray-700/50 shadow-sm hover:shadow-md transition-all duration-200'
-              title={
-                isChannelListCollapsed ? '显示频道列表' : '隐藏频道列表'
-              }
+              title={isChannelListCollapsed ? '显示频道列表' : '隐藏频道列表'}
             >
               <svg
-                className={`w-3.5 h-3.5 text-gray-500 dark:text-gray-400 transition-transform duration-200 ${isChannelListCollapsed ? 'rotate-180' : 'rotate-0'
-                  }`}
+                className={`w-3.5 h-3.5 text-gray-500 dark:text-gray-400 transition-transform duration-200 ${
+                  isChannelListCollapsed ? 'rotate-180' : 'rotate-0'
+                }`}
                 fill='none'
                 stroke='currentColor'
                 viewBox='0 0 24 24'
@@ -1662,20 +1879,28 @@ function LivePageClient() {
 
               {/* 精致的状态指示点 */}
               <div
-                className={`absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full transition-all duration-200 ${isChannelListCollapsed
-                  ? 'bg-orange-400 animate-pulse'
-                  : 'bg-green-400'
-                  }`}
+                className={`absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full transition-all duration-200 ${
+                  isChannelListCollapsed
+                    ? 'bg-orange-400 animate-pulse'
+                    : 'bg-green-400'
+                }`}
               ></div>
             </button>
           </div>
 
-          <div className={`grid gap-4 lg:h-[500px] xl:h-[650px] 2xl:h-[750px] transition-all duration-300 ease-in-out ${isChannelListCollapsed
-            ? 'grid-cols-1'
-            : 'grid-cols-1 md:grid-cols-4'
-            }`}>
+          <div
+            className={`grid gap-4 lg:h-[500px] xl:h-[650px] 2xl:h-[750px] transition-all duration-300 ease-in-out ${
+              isChannelListCollapsed
+                ? 'grid-cols-1'
+                : 'grid-cols-1 md:grid-cols-4'
+            }`}
+          >
             {/* 播放器 */}
-            <div className={`h-full transition-all duration-300 ease-in-out ${isChannelListCollapsed ? 'col-span-1' : 'md:col-span-3'}`}>
+            <div
+              className={`h-full transition-all duration-300 ease-in-out ${
+                isChannelListCollapsed ? 'col-span-1' : 'md:col-span-3'
+              }`}
+            >
               <div className='relative w-full h-[300px] lg:h-full'>
                 <div
                   ref={artRef}
@@ -1694,25 +1919,23 @@ function LivePageClient() {
                       </div>
                       <div className='space-y-4'>
                         <h3 className='text-xl font-semibold text-white'>
-                          {unsupportedType === 'channel-unavailable' ? '该频道暂时不可用' : '暂不支持的直播流类型'}
+                          {unsupportedType === 'channel-unavailable'
+                            ? '该频道暂时不可用'
+                            : '暂不支持的直播流类型'}
                         </h3>
                         <div className='bg-orange-500/20 border border-orange-500/30 rounded-lg p-4'>
                           <p className='text-orange-300 font-medium'>
-                            {unsupportedType === 'channel-unavailable' 
+                            {unsupportedType === 'channel-unavailable'
                               ? '频道可能需要特殊访问权限或链接已过期'
-                              : `当前频道直播流类型：${unsupportedType.toUpperCase()}`
-                            }
+                              : `当前频道直播流类型：${unsupportedType.toUpperCase()}`}
                           </p>
                           <p className='text-sm text-orange-200 mt-2'>
                             {unsupportedType === 'channel-unavailable'
                               ? '请联系IPTV提供商或尝试其他频道'
-                              : '目前仅支持 M3U8 格式的直播流'
-                            }
+                              : '目前仅支持 M3U8 格式的直播流'}
                           </p>
                         </div>
-                        <p className='text-sm text-gray-300'>
-                          请尝试其他频道
-                        </p>
+                        <p className='text-sm text-gray-300'>请尝试其他频道</p>
                       </div>
                     </div>
                   </div>
@@ -1784,19 +2007,23 @@ function LivePageClient() {
             </div>
 
             {/* 频道列表 */}
-            <div className={`h-[300px] lg:h-full md:overflow-hidden transition-all duration-300 ease-in-out ${isChannelListCollapsed
-              ? 'md:col-span-1 lg:hidden lg:opacity-0 lg:scale-95'
-              : 'md:col-span-1 lg:opacity-100 lg:scale-100'
-              }`}>
+            <div
+              className={`h-[300px] lg:h-full md:overflow-hidden transition-all duration-300 ease-in-out ${
+                isChannelListCollapsed
+                  ? 'md:col-span-1 lg:hidden lg:opacity-0 lg:scale-95'
+                  : 'md:col-span-1 lg:opacity-100 lg:scale-100'
+              }`}
+            >
               <div className='md:ml-2 px-4 py-0 h-full rounded-xl bg-black/10 dark:bg-white/5 flex flex-col border border-white/0 dark:border-white/30 overflow-hidden'>
                 {/* 主要的 Tab 切换 */}
                 <div className='flex mb-1 -mx-6 flex-shrink-0'>
                   <div
                     onClick={() => setActiveTab('channels')}
                     className={`flex-1 py-3 px-6 text-center cursor-pointer transition-all duration-200 font-medium
-                      ${activeTab === 'channels'
-                        ? 'text-green-600 dark:text-green-400'
-                        : 'text-gray-700 hover:text-green-600 bg-black/5 dark:bg-white/5 dark:text-gray-300 dark:hover:text-green-400 hover:bg-black/3 dark:hover:bg-white/3'
+                      ${
+                        activeTab === 'channels'
+                          ? 'text-green-600 dark:text-green-400'
+                          : 'text-gray-700 hover:text-green-600 bg-black/5 dark:bg-white/5 dark:text-gray-300 dark:hover:text-green-400 hover:bg-black/3 dark:hover:bg-white/3'
                       }
                     `.trim()}
                   >
@@ -1805,9 +2032,10 @@ function LivePageClient() {
                   <div
                     onClick={() => setActiveTab('sources')}
                     className={`flex-1 py-3 px-6 text-center cursor-pointer transition-all duration-200 font-medium
-                      ${activeTab === 'sources'
-                        ? 'text-green-600 dark:text-green-400'
-                        : 'text-gray-700 hover:text-green-600 bg-black/5 dark:bg-white/5 dark:text-gray-300 dark:hover:text-green-400 hover:bg-black/3 dark:hover:bg-white/3'
+                      ${
+                        activeTab === 'sources'
+                          ? 'text-green-600 dark:text-green-400'
+                          : 'text-gray-700 hover:text-green-600 bg-black/5 dark:bg-white/5 dark:text-gray-300 dark:hover:text-green-400 hover:bg-black/3 dark:hover:bg-white/3'
                       }
                     `.trim()}
                   >
@@ -1845,138 +2073,167 @@ function LivePageClient() {
                       <>
                         {/* 分组标签 */}
                         <div className='flex items-center gap-4 mb-4 border-b border-gray-300 dark:border-gray-700 -mx-6 px-6 flex-shrink-0'>
-                      {/* 切换状态提示 */}
-                      {isSwitchingSource && (
-                        <div className='flex items-center gap-2 text-sm text-amber-600 dark:text-amber-400'>
-                          <div className='w-2 h-2 bg-amber-500 rounded-full animate-pulse'></div>
-                          切换直播源中...
-                        </div>
-                      )}
-
-                      <div
-                        className='flex-1 overflow-x-auto'
-                        ref={groupContainerRef}
-                        onMouseEnter={() => {
-                          // 鼠标进入分组标签区域时，添加滚轮事件监听
-                          const container = groupContainerRef.current;
-                          if (container) {
-                            const handleWheel = (e: WheelEvent) => {
-                              if (container.scrollWidth > container.clientWidth) {
-                                e.preventDefault();
-                                container.scrollLeft += e.deltaY;
-                              }
-                            };
-                            container.addEventListener('wheel', handleWheel, { passive: false });
-                            // 将事件处理器存储在容器上，以便后续移除
-                            (container as any)._wheelHandler = handleWheel;
-                          }
-                        }}
-                        onMouseLeave={() => {
-                          // 鼠标离开分组标签区域时，移除滚轮事件监听
-                          const container = groupContainerRef.current;
-                          if (container && (container as any)._wheelHandler) {
-                            container.removeEventListener('wheel', (container as any)._wheelHandler);
-                            delete (container as any)._wheelHandler;
-                          }
-                        }}
-                      >
-                        <div className='flex gap-4 min-w-max'>
-                          {Object.keys(groupedChannels).map((group, index) => (
-                            <button
-                              key={group}
-                              data-group={group}
-                              ref={(el) => {
-                                groupButtonRefs.current[index] = el;
-                              }}
-                              onClick={() => handleGroupChange(group)}
-                              disabled={isSwitchingSource}
-                              className={`w-20 relative py-2 text-sm font-medium transition-colors flex-shrink-0 text-center overflow-hidden
-                                 ${isSwitchingSource
-                                  ? 'text-gray-400 dark:text-gray-600 cursor-not-allowed opacity-50'
-                                  : selectedGroup === group
-                                    ? 'text-green-500 dark:text-green-400'
-                                    : 'text-gray-700 hover:text-green-600 dark:text-gray-300 dark:hover:text-green-400'
-                                }
-                               `.trim()}
-                            >
-                              <div className='px-1 overflow-hidden whitespace-nowrap' title={group}>
-                                {group}
-                              </div>
-                              {selectedGroup === group && !isSwitchingSource && (
-                                <div className='absolute bottom-0 left-0 right-0 h-0.5 bg-green-500 dark:bg-green-400' />
-                              )}
-                            </button>
-                          ))}
-                        </div>
-                      </div>
-                    </div>
-
-                    {/* 频道列表 */}
-                    <div ref={channelListRef} className='flex-1 overflow-y-auto space-y-2 pb-4'>
-                      {filteredChannels.length > 0 ? (
-                        filteredChannels.map(channel => {
-                          const isActive = channel.id === currentChannel?.id;
-                          return (
-                            <button
-                              key={channel.id}
-                              data-channel-id={channel.id}
-                              onClick={() => handleChannelChange(channel)}
-                              disabled={isSwitchingSource}
-                              className={`w-full p-3 rounded-lg text-left transition-all duration-200 ${isSwitchingSource
-                                ? 'opacity-50 cursor-not-allowed'
-                                : isActive
-                                  ? 'bg-green-100 dark:bg-green-900/30 border border-green-300 dark:border-green-700'
-                                  : 'hover:bg-gray-100 dark:hover:bg-gray-700'
-                                }`}
-                            >
-                              <div className='flex items-center gap-3'>
-                                <div className='w-10 h-10 bg-gray-300 dark:bg-gray-700 rounded-lg flex items-center justify-center flex-shrink-0 overflow-hidden'>
-                                  {channel.logo ? (
-                                    <img
-                                      src={`/api/proxy/logo?url=${encodeURIComponent(channel.logo)}&source=${currentSource?.key || ''}`}
-                                      alt={channel.name}
-                                      className='w-full h-full rounded object-contain'
-                                      loading="lazy"
-                                    />
-                                  ) : (
-                                    <Tv className='w-5 h-5 text-gray-500' />
-                                  )}
-                                </div>
-                                <div className='flex-1 min-w-0'>
-                                  <div className='text-sm font-medium text-gray-900 dark:text-gray-100 overflow-hidden group/channelName'>
-                                    <span className='inline-block whitespace-nowrap group-hover/channelName:animate-scroll-text'>
-                                      {channel.name}
-                                    </span>
-                                  </div>
-                                  <div className='text-xs text-gray-500 dark:text-gray-400 mt-1 overflow-hidden group/channelGroup'>
-                                    <span className='inline-block whitespace-nowrap group-hover/channelGroup:animate-scroll-text'>
-                                      {channel.group}
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </button>
-                          );
-                        })
-                      ) : (
-                        <div className='flex flex-col items-center justify-center py-12 text-center'>
-                          <div className='relative mb-6'>
-                            <div className='w-20 h-20 bg-gradient-to-br from-gray-100 to-slate-200 dark:from-gray-700 dark:to-slate-700 rounded-2xl flex items-center justify-center shadow-lg'>
-                              <Tv className='w-10 h-10 text-gray-400 dark:text-gray-500' />
+                          {/* 切换状态提示 */}
+                          {isSwitchingSource && (
+                            <div className='flex items-center gap-2 text-sm text-amber-600 dark:text-amber-400'>
+                              <div className='w-2 h-2 bg-amber-500 rounded-full animate-pulse'></div>
+                              切换直播源中...
                             </div>
-                            {/* 装饰小点 */}
-                            <div className='absolute -top-1 -right-1 w-3 h-3 bg-blue-400 rounded-full animate-ping'></div>
-                            <div className='absolute -bottom-1 -left-1 w-2 h-2 bg-purple-400 rounded-full animate-pulse'></div>
+                          )}
+
+                          <div
+                            className='flex-1 overflow-x-auto'
+                            ref={groupContainerRef}
+                            onMouseEnter={() => {
+                              // 鼠标进入分组标签区域时，添加滚轮事件监听
+                              const container = groupContainerRef.current;
+                              if (container) {
+                                const handleWheel = (e: WheelEvent) => {
+                                  if (
+                                    container.scrollWidth >
+                                    container.clientWidth
+                                  ) {
+                                    e.preventDefault();
+                                    container.scrollLeft += e.deltaY;
+                                  }
+                                };
+                                container.addEventListener(
+                                  'wheel',
+                                  handleWheel,
+                                  { passive: false }
+                                );
+                                // 将事件处理器存储在容器上，以便后续移除
+                                (container as any)._wheelHandler = handleWheel;
+                              }
+                            }}
+                            onMouseLeave={() => {
+                              // 鼠标离开分组标签区域时，移除滚轮事件监听
+                              const container = groupContainerRef.current;
+                              if (
+                                container &&
+                                (container as any)._wheelHandler
+                              ) {
+                                container.removeEventListener(
+                                  'wheel',
+                                  (container as any)._wheelHandler
+                                );
+                                delete (container as any)._wheelHandler;
+                              }
+                            }}
+                          >
+                            <div className='flex gap-4 min-w-max'>
+                              {Object.keys(groupedChannels).map(
+                                (group, index) => (
+                                  <button
+                                    key={group}
+                                    data-group={group}
+                                    ref={(el) => {
+                                      groupButtonRefs.current[index] = el;
+                                    }}
+                                    onClick={() => handleGroupChange(group)}
+                                    disabled={isSwitchingSource}
+                                    className={`w-20 relative py-2 text-sm font-medium transition-colors flex-shrink-0 text-center overflow-hidden
+                                 ${
+                                   isSwitchingSource
+                                     ? 'text-gray-400 dark:text-gray-600 cursor-not-allowed opacity-50'
+                                     : selectedGroup === group
+                                     ? 'text-green-500 dark:text-green-400'
+                                     : 'text-gray-700 hover:text-green-600 dark:text-gray-300 dark:hover:text-green-400'
+                                 }
+                               `.trim()}
+                                  >
+                                    <div
+                                      className='px-1 overflow-hidden whitespace-nowrap'
+                                      title={group}
+                                    >
+                                      {group}
+                                    </div>
+                                    {selectedGroup === group &&
+                                      !isSwitchingSource && (
+                                        <div className='absolute bottom-0 left-0 right-0 h-0.5 bg-green-500 dark:bg-green-400' />
+                                      )}
+                                  </button>
+                                )
+                              )}
+                            </div>
                           </div>
-                          <p className='text-base font-semibold text-gray-700 dark:text-gray-300 mb-2'>
-                            暂无可用频道
-                          </p>
-                          <p className='text-sm text-gray-500 dark:text-gray-400'>
-                            请选择其他直播源或稍后再试
-                          </p>
                         </div>
-                      )}
-                    </div>
+
+                        {/* 频道列表 */}
+                        <div
+                          ref={channelListRef}
+                          className='flex-1 overflow-y-auto space-y-2 pb-4'
+                        >
+                          {filteredChannels.length > 0 ? (
+                            filteredChannels.map((channel) => {
+                              const isActive =
+                                channel.id === currentChannel?.id;
+                              return (
+                                <button
+                                  key={channel.id}
+                                  data-channel-id={channel.id}
+                                  onClick={() => handleChannelChange(channel)}
+                                  disabled={isSwitchingSource}
+                                  className={`w-full p-3 rounded-lg text-left transition-all duration-200 ${
+                                    isSwitchingSource
+                                      ? 'opacity-50 cursor-not-allowed'
+                                      : isActive
+                                      ? 'bg-green-100 dark:bg-green-900/30 border border-green-300 dark:border-green-700'
+                                      : 'hover:bg-gray-100 dark:hover:bg-gray-700'
+                                  }`}
+                                >
+                                  <div className='flex items-center gap-3'>
+                                    <div className='w-10 h-10 bg-gray-300 dark:bg-gray-700 rounded-lg flex items-center justify-center flex-shrink-0 overflow-hidden'>
+                                      {channel.logo ? (
+                                        <img
+                                          src={`/api/proxy/logo?url=${encodeURIComponent(
+                                            channel.logo
+                                          )}&source=${
+                                            currentSource?.key || ''
+                                          }`}
+                                          alt={channel.name}
+                                          className='w-full h-full rounded object-contain'
+                                          loading='lazy'
+                                        />
+                                      ) : (
+                                        <Tv className='w-5 h-5 text-gray-500' />
+                                      )}
+                                    </div>
+                                    <div className='flex-1 min-w-0'>
+                                      <div className='text-sm font-medium text-gray-900 dark:text-gray-100 overflow-hidden group/channelName'>
+                                        <span className='inline-block whitespace-nowrap group-hover/channelName:animate-scroll-text'>
+                                          {channel.name}
+                                        </span>
+                                      </div>
+                                      <div className='text-xs text-gray-500 dark:text-gray-400 mt-1 overflow-hidden group/channelGroup'>
+                                        <span className='inline-block whitespace-nowrap group-hover/channelGroup:animate-scroll-text'>
+                                          {channel.group}
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </button>
+                              );
+                            })
+                          ) : (
+                            <div className='flex flex-col items-center justify-center py-12 text-center'>
+                              <div className='relative mb-6'>
+                                <div className='w-20 h-20 bg-gradient-to-br from-gray-100 to-slate-200 dark:from-gray-700 dark:to-slate-700 rounded-2xl flex items-center justify-center shadow-lg'>
+                                  <Tv className='w-10 h-10 text-gray-400 dark:text-gray-500' />
+                                </div>
+                                {/* 装饰小点 */}
+                                <div className='absolute -top-1 -right-1 w-3 h-3 bg-blue-400 rounded-full animate-ping'></div>
+                                <div className='absolute -bottom-1 -left-1 w-2 h-2 bg-purple-400 rounded-full animate-pulse'></div>
+                              </div>
+                              <p className='text-base font-semibold text-gray-700 dark:text-gray-300 mb-2'>
+                                暂无可用频道
+                              </p>
+                              <p className='text-sm text-gray-500 dark:text-gray-400'>
+                                请选择其他直播源或稍后再试
+                              </p>
+                            </div>
+                          )}
+                        </div>
                       </>
                     ) : (
                       // 搜索结果显示（仅当前源）
@@ -1984,13 +2241,14 @@ function LivePageClient() {
                         {currentSourceSearchResults.length > 0 ? (
                           <div className='space-y-1 mb-2'>
                             <div className='text-xs text-gray-500 dark:text-gray-400 px-2'>
-                              在 "{currentSource?.name}" 中找到 {currentSourceSearchResults.length} 个频道
+                              在 "{currentSource?.name}" 中找到{' '}
+                              {currentSourceSearchResults.length} 个频道
                             </div>
                           </div>
                         ) : null}
-                        
+
                         {currentSourceSearchResults.length > 0 ? (
-                          currentSourceSearchResults.map(channel => {
+                          currentSourceSearchResults.map((channel) => {
                             const isActive = channel.id === currentChannel?.id;
                             return (
                               <button
@@ -2001,18 +2259,20 @@ function LivePageClient() {
                                   isSwitchingSource
                                     ? 'opacity-50 cursor-not-allowed'
                                     : isActive
-                                      ? 'bg-green-100 dark:bg-green-900/30 border border-green-300 dark:border-green-700'
-                                      : 'hover:bg-gray-100 dark:hover:bg-gray-700'
+                                    ? 'bg-green-100 dark:bg-green-900/30 border border-green-300 dark:border-green-700'
+                                    : 'hover:bg-gray-100 dark:hover:bg-gray-700'
                                 }`}
                               >
                                 <div className='flex items-center gap-3'>
                                   <div className='w-10 h-10 bg-gray-300 dark:bg-gray-700 rounded-lg flex items-center justify-center flex-shrink-0 overflow-hidden'>
                                     {channel.logo ? (
                                       <img
-                                        src={`/api/proxy/logo?url=${encodeURIComponent(channel.logo)}&source=${currentSource?.key || ''}`}
+                                        src={`/api/proxy/logo?url=${encodeURIComponent(
+                                          channel.logo
+                                        )}&source=${currentSource?.key || ''}`}
                                         alt={channel.name}
                                         className='w-full h-full rounded object-contain'
-                                        loading="lazy"
+                                        loading='lazy'
                                       />
                                     ) : (
                                       <Tv className='w-5 h-5 text-gray-500' />
@@ -2023,11 +2283,18 @@ function LivePageClient() {
                                       <span
                                         className='inline-block whitespace-nowrap group-hover/searchName:animate-scroll-text'
                                         dangerouslySetInnerHTML={{
-                                          __html: searchQuery ?
-                                            channel.name.replace(
-                                              new RegExp(`(${searchQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi'),
-                                              '<mark class="bg-yellow-200 dark:bg-yellow-800 px-0.5 rounded">$1</mark>'
-                                            ) : channel.name
+                                          __html: searchQuery
+                                            ? channel.name.replace(
+                                                new RegExp(
+                                                  `(${searchQuery.replace(
+                                                    /[.*+?^${}()|[\]\\]/g,
+                                                    '\\$&'
+                                                  )})`,
+                                                  'gi'
+                                                ),
+                                                '<mark class="bg-yellow-200 dark:bg-yellow-800 px-0.5 rounded">$1</mark>'
+                                              )
+                                            : channel.name,
                                         }}
                                       />
                                     </div>
@@ -2050,7 +2317,8 @@ function LivePageClient() {
                               未找到匹配的频道
                             </p>
                             <p className='text-sm text-gray-400 dark:text-gray-500 mt-1'>
-                              在当前直播源 "{currentSource?.name}" 中未找到匹配结果
+                              在当前直播源 "{currentSource?.name}"
+                              中未找到匹配结果
                             </p>
                           </div>
                         )}
@@ -2070,7 +2338,9 @@ function LivePageClient() {
                           type='text'
                           placeholder='搜索直播源...'
                           value={sourceSearchQuery}
-                          onChange={(e) => handleSourceSearchChange(e.target.value)}
+                          onChange={(e) =>
+                            handleSourceSearchChange(e.target.value)
+                          }
                           className='w-full pl-10 pr-8 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg text-sm focus:ring-2 focus:ring-green-500 focus:border-transparent'
                         />
                         {sourceSearchQuery && (
@@ -2093,11 +2363,15 @@ function LivePageClient() {
                           disabled={isRefreshingSource}
                           className='flex items-center gap-2 px-3 py-2 bg-blue-500 hover:bg-blue-600 disabled:bg-gray-400 text-white text-sm rounded-lg transition-colors flex-1'
                         >
-                          <RefreshCw className={`w-4 h-4 ${isRefreshingSource ? 'animate-spin' : ''}`} />
+                          <RefreshCw
+                            className={`w-4 h-4 ${
+                              isRefreshingSource ? 'animate-spin' : ''
+                            }`}
+                          />
                           {isRefreshingSource ? '刷新中...' : '刷新源'}
                         </button>
                       </div>
-                      
+
                       {/* 自动刷新控制 */}
                       <div className='flex items-center gap-3'>
                         <div className='flex items-center gap-2'>
@@ -2105,19 +2379,26 @@ function LivePageClient() {
                             type='checkbox'
                             id='autoRefresh'
                             checked={autoRefreshEnabled}
-                            onChange={(e) => setAutoRefreshEnabled(e.target.checked)}
+                            onChange={(e) =>
+                              setAutoRefreshEnabled(e.target.checked)
+                            }
                             className='rounded text-green-500 focus:ring-green-500'
                           />
-                          <label htmlFor='autoRefresh' className='text-sm text-gray-700 dark:text-gray-300'>
+                          <label
+                            htmlFor='autoRefresh'
+                            className='text-sm text-gray-700 dark:text-gray-300'
+                          >
                             自动刷新
                           </label>
                         </div>
-                        
+
                         {autoRefreshEnabled && (
                           <div className='flex items-center gap-2'>
                             <select
                               value={autoRefreshInterval}
-                              onChange={(e) => setAutoRefreshInterval(Number(e.target.value))}
+                              onChange={(e) =>
+                                setAutoRefreshInterval(Number(e.target.value))
+                              }
                               className='text-xs px-2 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100'
                             >
                               <option value={10}>10分钟</option>
@@ -2143,15 +2424,19 @@ function LivePageClient() {
                     <div className='flex-1 overflow-y-auto space-y-2 pb-20'>
                       {filteredSources.length > 0 ? (
                         filteredSources.map((source) => {
-                          const isCurrentSource = source.key === currentSource?.key;
+                          const isCurrentSource =
+                            source.key === currentSource?.key;
                           return (
                             <div
                               key={source.key}
-                              onClick={() => !isCurrentSource && handleSourceChange(source)}
+                              onClick={() =>
+                                !isCurrentSource && handleSourceChange(source)
+                              }
                               className={`flex items-start gap-3 px-2 py-3 rounded-lg transition-all select-none duration-200 relative
-                                ${isCurrentSource
-                                  ? 'bg-green-500/10 dark:bg-green-500/20 border-green-500/30 border'
-                                  : 'hover:bg-gray-200/50 dark:hover:bg-white/10 hover:scale-[1.02] cursor-pointer'
+                                ${
+                                  isCurrentSource
+                                    ? 'bg-green-500/10 dark:bg-green-500/20 border-green-500/30 border'
+                                    : 'hover:bg-gray-200/50 dark:hover:bg-white/10 hover:scale-[1.02] cursor-pointer'
                                 }`.trim()}
                             >
                               {/* 图标 */}
@@ -2166,9 +2451,15 @@ function LivePageClient() {
                                     <span
                                       dangerouslySetInnerHTML={{
                                         __html: source.name.replace(
-                                          new RegExp(`(${sourceSearchQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi'),
+                                          new RegExp(
+                                            `(${sourceSearchQuery.replace(
+                                              /[.*+?^${}()|[\]\\]/g,
+                                              '\\$&'
+                                            )})`,
+                                            'gi'
+                                          ),
                                           '<mark class="bg-yellow-200 dark:bg-yellow-800 px-0.5 rounded">$1</mark>'
-                                        )
+                                        ),
                                       }}
                                     />
                                   ) : (
@@ -2176,7 +2467,10 @@ function LivePageClient() {
                                   )}
                                 </div>
                                 <div className='text-xs text-gray-500 dark:text-gray-400 mt-1'>
-                                  {!source.channelNumber || source.channelNumber === 0 ? '-' : `${source.channelNumber} 个频道`}
+                                  {!source.channelNumber ||
+                                  source.channelNumber === 0
+                                    ? '-'
+                                    : `${source.channelNumber} 个频道`}
                                 </div>
                               </div>
 
@@ -2241,10 +2535,12 @@ function LivePageClient() {
                   <div className='w-20 h-20 bg-gray-300 dark:bg-gray-700 rounded-lg flex items-center justify-center flex-shrink-0 overflow-hidden'>
                     {currentChannel.logo ? (
                       <img
-                        src={`/api/proxy/logo?url=${encodeURIComponent(currentChannel.logo)}&source=${currentSource?.key || ''}`}
+                        src={`/api/proxy/logo?url=${encodeURIComponent(
+                          currentChannel.logo
+                        )}&source=${currentSource?.key || ''}`}
                         alt={currentChannel.name}
                         className='w-full h-full rounded object-contain'
-                        loading="lazy"
+                        loading='lazy'
                       />
                     ) : (
                       <Tv className='w-10 h-10 text-gray-500' />

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -24,21 +24,21 @@ import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import { getAuthInfoFromBrowserCookie } from '@/lib/auth';
+import {
+  type PlayRecord,
+  forceRefreshPlayRecordsCache,
+  getAllPlayRecords,
+} from '@/lib/db.client';
+import type { Favorite } from '@/lib/types';
 import { CURRENT_VERSION } from '@/lib/version';
 import { checkForUpdates, UpdateStatus } from '@/lib/version_check';
 import {
+  type WatchingUpdate,
+  checkWatchingUpdates,
   getCachedWatchingUpdates,
   getDetailedWatchingUpdates,
   subscribeToWatchingUpdatesEvent,
-  checkWatchingUpdates,
-  type WatchingUpdate,
 } from '@/lib/watching-updates';
-import {
-  getAllPlayRecords,
-  forceRefreshPlayRecordsCache,
-  type PlayRecord,
-} from '@/lib/db.client';
-import type { Favorite } from '@/lib/types';
 
 import { VersionPanel } from './VersionPanel';
 import VideoCard from './VideoCard';
@@ -58,22 +58,37 @@ export const UserMenu: React.FC = () => {
   const [isContinueWatchingOpen, setIsContinueWatchingOpen] = useState(false);
   const [isFavoritesOpen, setIsFavoritesOpen] = useState(false);
   const [authInfo, setAuthInfo] = useState<AuthInfo | null>(null);
-  const [storageType, setStorageType] = useState<string>(() => {
+  const [storageType, _setStorageType] = useState<string>(() => {
     // 🔧 优化：直接从 RUNTIME_CONFIG 读取初始值，避免默认值导致的多次渲染
     if (typeof window !== 'undefined') {
-      return (window as any).RUNTIME_CONFIG?.STORAGE_TYPE || 'localstorage';
+      return (
+        (window as Record<string, unknown>).RUNTIME_CONFIG?.STORAGE_TYPE ||
+        'localstorage'
+      );
     }
     return 'localstorage';
   });
   const [mounted, setMounted] = useState(false);
-  const [watchingUpdates, setWatchingUpdates] = useState<WatchingUpdate | null>(null);
-  const [playRecords, setPlayRecords] = useState<(PlayRecord & { key: string })[]>([]);
-  const [favorites, setFavorites] = useState<(Favorite & { key: string })[]>([]);
+  const [watchingUpdates, setWatchingUpdates] = useState<WatchingUpdate | null>(
+    null
+  );
+  const [playRecords, setPlayRecords] = useState<
+    (PlayRecord & { key: string })[]
+  >([]);
+  const [favorites, setFavorites] = useState<(Favorite & { key: string })[]>(
+    []
+  );
   const [hasUnreadUpdates, setHasUnreadUpdates] = useState(false);
 
   // Body 滚动锁定 - 使用 overflow 方式避免布局问题
   useEffect(() => {
-    if (isSettingsOpen || isChangePasswordOpen || isWatchingUpdatesOpen || isContinueWatchingOpen || isFavoritesOpen) {
+    if (
+      isSettingsOpen ||
+      isChangePasswordOpen ||
+      isWatchingUpdatesOpen ||
+      isContinueWatchingOpen ||
+      isFavoritesOpen
+    ) {
       const body = document.body;
       const html = document.documentElement;
 
@@ -86,13 +101,18 @@ export const UserMenu: React.FC = () => {
       html.style.overflow = 'hidden';
 
       return () => {
-
         // 恢复所有原始样式
         body.style.overflow = originalBodyOverflow;
         html.style.overflow = originalHtmlOverflow;
       };
     }
-  }, [isSettingsOpen, isChangePasswordOpen, isWatchingUpdatesOpen, isContinueWatchingOpen, isFavoritesOpen]);
+  }, [
+    isSettingsOpen,
+    isChangePasswordOpen,
+    isWatchingUpdatesOpen,
+    isContinueWatchingOpen,
+    isFavoritesOpen,
+  ]);
 
   // 设置相关状态
   const [defaultAggregateSearch, setDefaultAggregateSearch] = useState(true);
@@ -103,9 +123,12 @@ export const UserMenu: React.FC = () => {
   const [doubanDataSource, setDoubanDataSource] = useState('direct');
   const [doubanImageProxyType, setDoubanImageProxyType] = useState('direct');
   const [doubanImageProxyUrl, setDoubanImageProxyUrl] = useState('');
-  const [continueWatchingMinProgress, setContinueWatchingMinProgress] = useState(5);
-  const [continueWatchingMaxProgress, setContinueWatchingMaxProgress] = useState(100);
-  const [enableContinueWatchingFilter, setEnableContinueWatchingFilter] = useState(false);
+  const [continueWatchingMinProgress, setContinueWatchingMinProgress] =
+    useState(5);
+  const [continueWatchingMaxProgress, setContinueWatchingMaxProgress] =
+    useState(100);
+  const [enableContinueWatchingFilter, setEnableContinueWatchingFilter] =
+    useState(false);
   const [isDoubanDropdownOpen, setIsDoubanDropdownOpen] = useState(false);
   const [isDoubanImageProxyDropdownOpen, setIsDoubanImageProxyDropdownOpen] =
     useState(false);
@@ -231,19 +254,31 @@ export const UserMenu: React.FC = () => {
         setLiveDirectConnect(JSON.parse(savedLiveDirectConnect));
       }
 
-      const savedContinueWatchingMinProgress = localStorage.getItem('continueWatchingMinProgress');
+      const savedContinueWatchingMinProgress = localStorage.getItem(
+        'continueWatchingMinProgress'
+      );
       if (savedContinueWatchingMinProgress !== null) {
-        setContinueWatchingMinProgress(parseInt(savedContinueWatchingMinProgress));
+        setContinueWatchingMinProgress(
+          parseInt(savedContinueWatchingMinProgress)
+        );
       }
 
-      const savedContinueWatchingMaxProgress = localStorage.getItem('continueWatchingMaxProgress');
+      const savedContinueWatchingMaxProgress = localStorage.getItem(
+        'continueWatchingMaxProgress'
+      );
       if (savedContinueWatchingMaxProgress !== null) {
-        setContinueWatchingMaxProgress(parseInt(savedContinueWatchingMaxProgress));
+        setContinueWatchingMaxProgress(
+          parseInt(savedContinueWatchingMaxProgress)
+        );
       }
 
-      const savedEnableContinueWatchingFilter = localStorage.getItem('enableContinueWatchingFilter');
+      const savedEnableContinueWatchingFilter = localStorage.getItem(
+        'enableContinueWatchingFilter'
+      );
       if (savedEnableContinueWatchingFilter !== null) {
-        setEnableContinueWatchingFilter(JSON.parse(savedEnableContinueWatchingFilter));
+        setEnableContinueWatchingFilter(
+          JSON.parse(savedEnableContinueWatchingFilter)
+        );
       }
 
       // 读取跳过片头片尾设置（默认开启）
@@ -252,7 +287,9 @@ export const UserMenu: React.FC = () => {
         setEnableAutoSkip(JSON.parse(savedEnableAutoSkip));
       }
 
-      const savedEnableAutoNextEpisode = localStorage.getItem('enableAutoNextEpisode');
+      const savedEnableAutoNextEpisode = localStorage.getItem(
+        'enableAutoNextEpisode'
+      );
       if (savedEnableAutoNextEpisode !== null) {
         setEnableAutoNextEpisode(JSON.parse(savedEnableAutoNextEpisode));
       }
@@ -278,13 +315,17 @@ export const UserMenu: React.FC = () => {
   // 获取观看更新信息
   useEffect(() => {
     console.log('UserMenu watching-updates 检查条件:', {
-      'window': typeof window !== 'undefined',
+      window: typeof window !== 'undefined',
       'authInfo.username': authInfo?.username,
-      'storageType': storageType,
-      'storageType !== localstorage': storageType !== 'localstorage'
+      storageType: storageType,
+      'storageType !== localstorage': storageType !== 'localstorage',
     });
 
-    if (typeof window !== 'undefined' && authInfo?.username && storageType !== 'localstorage') {
+    if (
+      typeof window !== 'undefined' &&
+      authInfo?.username &&
+      storageType !== 'localstorage'
+    ) {
       console.log('开始加载 watching-updates 数据...');
 
       const updateWatchingUpdates = () => {
@@ -294,11 +335,14 @@ export const UserMenu: React.FC = () => {
 
         // 检测是否有新更新（只检查新剧集更新，不包括继续观看）
         if (updates && (updates.updatedCount || 0) > 0) {
-          const lastViewed = parseInt(localStorage.getItem('watchingUpdatesLastViewed') || '0');
+          const lastViewed = parseInt(
+            localStorage.getItem('watchingUpdatesLastViewed') || '0'
+          );
           const currentTime = Date.now();
 
           // 如果从未查看过，或者距离上次查看超过1分钟，认为有新更新
-          const hasNewUpdates = lastViewed === 0 || (currentTime - lastViewed > 60000);
+          const hasNewUpdates =
+            lastViewed === 0 || currentTime - lastViewed > 60000;
           setHasUnreadUpdates(hasNewUpdates);
         } else {
           setHasUnreadUpdates(false);
@@ -349,7 +393,11 @@ export const UserMenu: React.FC = () => {
 
   // 加载播放记录（优化版）
   useEffect(() => {
-    if (typeof window !== 'undefined' && authInfo?.username && storageType !== 'localstorage') {
+    if (
+      typeof window !== 'undefined' &&
+      authInfo?.username &&
+      storageType !== 'localstorage'
+    ) {
       const loadPlayRecords = async () => {
         try {
           const records = await getAllPlayRecords();
@@ -359,7 +407,7 @@ export const UserMenu: React.FC = () => {
           }));
 
           // 筛选真正需要继续观看的记录
-          const validPlayRecords = recordsArray.filter(record => {
+          const validPlayRecords = recordsArray.filter((record) => {
             const progress = getProgress(record);
 
             // 播放时间必须超过2分钟
@@ -369,11 +417,16 @@ export const UserMenu: React.FC = () => {
             if (!enableContinueWatchingFilter) return true;
 
             // 根据用户自定义的进度范围筛选
-            return progress >= continueWatchingMinProgress && progress <= continueWatchingMaxProgress;
+            return (
+              progress >= continueWatchingMinProgress &&
+              progress <= continueWatchingMaxProgress
+            );
           });
 
           // 按最后播放时间降序排列
-          const sortedRecords = validPlayRecords.sort((a, b) => b.save_time - a.save_time);
+          const sortedRecords = validPlayRecords.sort(
+            (a, b) => b.save_time - a.save_time
+          );
           setPlayRecords(sortedRecords.slice(0, 12)); // 只取最近的12个
         } catch (error) {
           console.error('加载播放记录失败:', error);
@@ -404,43 +457,70 @@ export const UserMenu: React.FC = () => {
           // 短暂延迟后重新获取播放记录，确保缓存已刷新
           setTimeout(async () => {
             const freshRecords = await getAllPlayRecords();
-            const recordsArray = Object.entries(freshRecords).map(([key, record]) => ({
-              ...record,
-              key,
-            }));
-            const validPlayRecords = recordsArray.filter(record => {
+            const recordsArray = Object.entries(freshRecords).map(
+              ([key, record]) => ({
+                ...record,
+                key,
+              })
+            );
+            const validPlayRecords = recordsArray.filter((record) => {
               const progress = getProgress(record);
               if (record.play_time < 120) return false;
               if (!enableContinueWatchingFilter) return true;
-              return progress >= continueWatchingMinProgress && progress <= continueWatchingMaxProgress;
+              return (
+                progress >= continueWatchingMinProgress &&
+                progress <= continueWatchingMaxProgress
+              );
             });
-            const sortedRecords = validPlayRecords.sort((a, b) => b.save_time - a.save_time);
+            const sortedRecords = validPlayRecords.sort(
+              (a, b) => b.save_time - a.save_time
+            );
             setPlayRecords(sortedRecords.slice(0, 12));
           }, 100);
         }
       });
 
       return () => {
-        window.removeEventListener('playRecordsUpdated', handlePlayRecordsUpdate);
+        window.removeEventListener(
+          'playRecordsUpdated',
+          handlePlayRecordsUpdate
+        );
         unsubscribeWatchingUpdates(); // 🔥 清理watching-updates订阅
       };
     }
-  }, [authInfo, storageType, enableContinueWatchingFilter, continueWatchingMinProgress, continueWatchingMaxProgress]);
+  }, [
+    authInfo,
+    storageType,
+    enableContinueWatchingFilter,
+    continueWatchingMinProgress,
+    continueWatchingMaxProgress,
+  ]);
 
   // 加载收藏数据
   useEffect(() => {
-    if (typeof window !== 'undefined' && authInfo?.username && storageType !== 'localstorage') {
+    if (
+      typeof window !== 'undefined' &&
+      authInfo?.username &&
+      storageType !== 'localstorage'
+    ) {
       const loadFavorites = async () => {
         try {
           const response = await fetch('/api/favorites');
           if (response.ok) {
-            const favoritesData = await response.json() as Record<string, Favorite>;
-            const favoritesArray = Object.entries(favoritesData).map(([key, favorite]) => ({
-              ...(favorite as Favorite),
-              key,
-            }));
+            const favoritesData = (await response.json()) as Record<
+              string,
+              Favorite
+            >;
+            const favoritesArray = Object.entries(favoritesData).map(
+              ([key, favorite]) => ({
+                ...(favorite as Favorite),
+                key,
+              })
+            );
             // 按保存时间降序排列
-            const sortedFavorites = favoritesArray.sort((a, b) => b.save_time - a.save_time);
+            const sortedFavorites = favoritesArray.sort(
+              (a, b) => b.save_time - a.save_time
+            );
             setFavorites(sortedFavorites);
           }
         } catch (error) {
@@ -526,9 +606,12 @@ export const UserMenu: React.FC = () => {
 
         // 重新计算未读状态
         if (updates && (updates.updatedCount || 0) > 0) {
-          const lastViewed = parseInt(localStorage.getItem('watchingUpdatesLastViewed') || '0');
+          const lastViewed = parseInt(
+            localStorage.getItem('watchingUpdatesLastViewed') || '0'
+          );
           const currentTime = Date.now();
-          const hasNewUpdates = lastViewed === 0 || (currentTime - lastViewed > 60000);
+          const hasNewUpdates =
+            lastViewed === 0 || currentTime - lastViewed > 60000;
           setHasUnreadUpdates(hasNewUpdates);
         } else {
           setHasUnreadUpdates(false);
@@ -564,6 +647,11 @@ export const UserMenu: React.FC = () => {
   const handlePlayStats = () => {
     setIsOpen(false);
     router.push('/play-stats');
+  };
+
+  const handleLiveStats = () => {
+    setIsOpen(false);
+    router.push('/admin/live-stats');
   };
 
   const handleTVBoxConfig = () => {
@@ -620,19 +708,22 @@ export const UserMenu: React.FC = () => {
   };
 
   // 检查播放记录是否有新集数更新
-  const getNewEpisodesCount = (record: PlayRecord & { key: string }): number => {
+  const getNewEpisodesCount = (
+    record: PlayRecord & { key: string }
+  ): number => {
     if (!watchingUpdates || !watchingUpdates.updatedSeries) return 0;
 
     const { source, id } = parseKey(record.key);
 
     // 在watchingUpdates中查找匹配的剧集
-    const matchedSeries = watchingUpdates.updatedSeries.find(series =>
-      series.sourceKey === source &&
-      series.videoId === id &&
-      series.hasNewEpisode
+    const matchedSeries = watchingUpdates.updatedSeries.find(
+      (series) =>
+        series.sourceKey === source &&
+        series.videoId === id &&
+        series.hasNewEpisode
     );
 
-    return matchedSeries ? (matchedSeries.newEpisodes || 0) : 0;
+    return matchedSeries ? matchedSeries.newEpisodes || 0 : 0;
   };
 
   const handleChangePassword = () => {
@@ -756,7 +847,10 @@ export const UserMenu: React.FC = () => {
   const handleEnableContinueWatchingFilterToggle = (value: boolean) => {
     setEnableContinueWatchingFilter(value);
     if (typeof window !== 'undefined') {
-      localStorage.setItem('enableContinueWatchingFilter', JSON.stringify(value));
+      localStorage.setItem(
+        'enableContinueWatchingFilter',
+        JSON.stringify(value)
+      );
     }
   };
 
@@ -855,7 +949,10 @@ export const UserMenu: React.FC = () => {
       localStorage.setItem('doubanImageProxyUrl', defaultDoubanImageProxyUrl);
       localStorage.setItem('continueWatchingMinProgress', '5');
       localStorage.setItem('continueWatchingMaxProgress', '100');
-      localStorage.setItem('enableContinueWatchingFilter', JSON.stringify(false));
+      localStorage.setItem(
+        'enableContinueWatchingFilter',
+        JSON.stringify(false)
+      );
       localStorage.setItem('enableAutoSkip', JSON.stringify(true));
       localStorage.setItem('enableAutoNextEpisode', JSON.stringify(true));
     }
@@ -873,10 +970,12 @@ export const UserMenu: React.FC = () => {
   const showPlayStats = authInfo?.username && storageType !== 'localstorage';
 
   // 检查是否显示更新提醒按钮（登录用户且非localstorage存储就显示）
-  const showWatchingUpdates = authInfo?.username && storageType !== 'localstorage';
+  const showWatchingUpdates =
+    authInfo?.username && storageType !== 'localstorage';
 
   // 检查是否有实际更新（用于显示红点）- 只检查新剧集更新
-  const hasActualUpdates = watchingUpdates && (watchingUpdates.updatedCount || 0) > 0;
+  const hasActualUpdates =
+    watchingUpdates && (watchingUpdates.updatedCount || 0) > 0;
 
   // 计算更新数量（只统计新剧集更新）
   const totalUpdates = watchingUpdates?.updatedCount || 0;
@@ -888,7 +987,7 @@ export const UserMenu: React.FC = () => {
     watchingUpdates,
     showWatchingUpdates,
     hasActualUpdates,
-    totalUpdates
+    totalUpdates,
   });
 
   // 角色中文映射
@@ -924,12 +1023,13 @@ export const UserMenu: React.FC = () => {
                 当前用户
               </span>
               <span
-                className={`inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-medium ${(authInfo?.role || 'user') === 'owner'
-                  ? 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300'
-                  : (authInfo?.role || 'user') === 'admin'
+                className={`inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-medium ${
+                  (authInfo?.role || 'user') === 'owner'
+                    ? 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300'
+                    : (authInfo?.role || 'user') === 'admin'
                     ? 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300'
                     : 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
-                  }`}
+                }`}
               >
                 {getRoleText(authInfo?.role || 'user')}
               </span>
@@ -984,7 +1084,9 @@ export const UserMenu: React.FC = () => {
               <PlayCircle className='w-4 h-4 text-gray-500 dark:text-gray-400' />
               <span className='font-medium'>继续观看</span>
               {playRecords.length > 0 && (
-                <span className='ml-auto text-xs text-gray-400'>{playRecords.length}</span>
+                <span className='ml-auto text-xs text-gray-400'>
+                  {playRecords.length}
+                </span>
               )}
             </button>
           )}
@@ -998,7 +1100,9 @@ export const UserMenu: React.FC = () => {
               <Heart className='w-4 h-4 text-gray-500 dark:text-gray-400' />
               <span className='font-medium'>我的收藏</span>
               {favorites.length > 0 && (
-                <span className='ml-auto text-xs text-gray-400'>{favorites.length}</span>
+                <span className='ml-auto text-xs text-gray-400'>
+                  {favorites.length}
+                </span>
               )}
             </button>
           )}
@@ -1022,8 +1126,21 @@ export const UserMenu: React.FC = () => {
             >
               <BarChart3 className='w-4 h-4 text-gray-500 dark:text-gray-400' />
               <span className='font-medium'>
-                {authInfo?.role === 'owner' || authInfo?.role === 'admin' ? '播放统计' : '个人统计'}
+                {authInfo?.role === 'owner' || authInfo?.role === 'admin'
+                  ? '播放统计'
+                  : '个人统计'}
               </span>
+            </button>
+          )}
+
+          {/* 直播统计按钮 */}
+          {showPlayStats && (
+            <button
+              onClick={handleLiveStats}
+              className='w-full px-3 py-2 text-left flex items-center gap-2.5 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors text-sm'
+            >
+              <Tv className='w-4 h-4 text-gray-500 dark:text-gray-400' />
+              <span className='font-medium'>直播统计</span>
             </button>
           )}
 
@@ -1085,12 +1202,13 @@ export const UserMenu: React.FC = () => {
                 updateStatus &&
                 updateStatus !== UpdateStatus.FETCH_FAILED && (
                   <div
-                    className={`w-2 h-2 rounded-full -translate-y-2 ${updateStatus === UpdateStatus.HAS_UPDATE
-                      ? 'bg-yellow-500'
-                      : updateStatus === UpdateStatus.NO_UPDATE
+                    className={`w-2 h-2 rounded-full -translate-y-2 ${
+                      updateStatus === UpdateStatus.HAS_UPDATE
+                        ? 'bg-yellow-500'
+                        : updateStatus === UpdateStatus.NO_UPDATE
                         ? 'bg-green-400'
                         : ''
-                      }`}
+                    }`}
                   ></div>
                 )}
             </div>
@@ -1121,9 +1239,7 @@ export const UserMenu: React.FC = () => {
       />
 
       {/* 设置面板 */}
-      <div
-        className='fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-xl max-h-[90vh] bg-white dark:bg-gray-900 rounded-xl shadow-xl z-[1001] flex flex-col'
-      >
+      <div className='fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-xl max-h-[90vh] bg-white dark:bg-gray-900 rounded-xl shadow-xl z-[1001] flex flex-col'>
         {/* 内容容器 - 独立的滚动区域 */}
         <div
           className='flex-1 p-6 overflow-y-auto'
@@ -1185,8 +1301,9 @@ export const UserMenu: React.FC = () => {
                 {/* 下拉箭头 */}
                 <div className='absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none'>
                   <ChevronDown
-                    className={`w-4 h-4 text-gray-400 dark:text-gray-500 transition-transform duration-200 ${isDoubanDropdownOpen ? 'rotate-180' : ''
-                      }`}
+                    className={`w-4 h-4 text-gray-400 dark:text-gray-500 transition-transform duration-200 ${
+                      isDoubanDropdownOpen ? 'rotate-180' : ''
+                    }`}
                   />
                 </div>
 
@@ -1201,10 +1318,11 @@ export const UserMenu: React.FC = () => {
                           handleDoubanDataSourceChange(option.value);
                           setIsDoubanDropdownOpen(false);
                         }}
-                        className={`w-full px-3 py-2.5 text-left text-sm transition-colors duration-150 flex items-center justify-between hover:bg-gray-100 dark:hover:bg-gray-700 ${doubanDataSource === option.value
-                          ? 'bg-green-50 dark:bg-green-900/20 text-green-600 dark:text-green-400'
-                          : 'text-gray-900 dark:text-gray-100'
-                          }`}
+                        className={`w-full px-3 py-2.5 text-left text-sm transition-colors duration-150 flex items-center justify-between hover:bg-gray-100 dark:hover:bg-gray-700 ${
+                          doubanDataSource === option.value
+                            ? 'bg-green-50 dark:bg-green-900/20 text-green-600 dark:text-green-400'
+                            : 'text-gray-900 dark:text-gray-100'
+                        }`}
                       >
                         <span className='truncate'>{option.label}</span>
                         {doubanDataSource === option.value && (
@@ -1222,7 +1340,10 @@ export const UserMenu: React.FC = () => {
                   <button
                     type='button'
                     onClick={() =>
-                      window.open(getThanksInfo(doubanDataSource)!.url, '_blank')
+                      window.open(
+                        getThanksInfo(doubanDataSource)!.url,
+                        '_blank'
+                      )
                     }
                     className='flex items-center justify-center gap-1.5 w-full px-3 text-xs text-gray-500 dark:text-gray-400 cursor-pointer'
                   >
@@ -1290,8 +1411,9 @@ export const UserMenu: React.FC = () => {
                 {/* 下拉箭头 */}
                 <div className='absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none'>
                   <ChevronDown
-                    className={`w-4 h-4 text-gray-400 dark:text-gray-500 transition-transform duration-200 ${isDoubanDropdownOpen ? 'rotate-180' : ''
-                      }`}
+                    className={`w-4 h-4 text-gray-400 dark:text-gray-500 transition-transform duration-200 ${
+                      isDoubanDropdownOpen ? 'rotate-180' : ''
+                    }`}
                   />
                 </div>
 
@@ -1306,10 +1428,11 @@ export const UserMenu: React.FC = () => {
                           handleDoubanImageProxyTypeChange(option.value);
                           setIsDoubanImageProxyDropdownOpen(false);
                         }}
-                        className={`w-full px-3 py-2.5 text-left text-sm transition-colors duration-150 flex items-center justify-between hover:bg-gray-100 dark:hover:bg-gray-700 ${doubanImageProxyType === option.value
-                          ? 'bg-green-50 dark:bg-green-900/20 text-green-600 dark:text-green-400'
-                          : 'text-gray-900 dark:text-gray-100'
-                          }`}
+                        className={`w-full px-3 py-2.5 text-left text-sm transition-colors duration-150 flex items-center justify-between hover:bg-gray-100 dark:hover:bg-gray-700 ${
+                          doubanImageProxyType === option.value
+                            ? 'bg-green-50 dark:bg-green-900/20 text-green-600 dark:text-green-400'
+                            : 'text-gray-900 dark:text-gray-100'
+                        }`}
                       >
                         <span className='truncate'>{option.label}</span>
                         {doubanImageProxyType === option.value && (
@@ -1457,7 +1580,9 @@ export const UserMenu: React.FC = () => {
                     type='checkbox'
                     className='sr-only peer'
                     checked={liveDirectConnect}
-                    onChange={(e) => handleLiveDirectConnectToggle(e.target.checked)}
+                    onChange={(e) =>
+                      handleLiveDirectConnectToggle(e.target.checked)
+                    }
                   />
                   <div className='w-11 h-6 bg-gray-300 rounded-full peer-checked:bg-green-500 transition-colors dark:bg-gray-600'></div>
                   <div className='absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform peer-checked:translate-x-5'></div>
@@ -1495,7 +1620,9 @@ export const UserMenu: React.FC = () => {
                       type='checkbox'
                       className='sr-only peer'
                       checked={enableAutoSkip}
-                      onChange={(e) => handleEnableAutoSkipToggle(e.target.checked)}
+                      onChange={(e) =>
+                        handleEnableAutoSkipToggle(e.target.checked)
+                      }
                     />
                     <div className='w-11 h-6 bg-gray-300 rounded-full peer-checked:bg-green-500 transition-colors dark:bg-gray-600'></div>
                     <div className='absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform peer-checked:translate-x-5'></div>
@@ -1519,7 +1646,9 @@ export const UserMenu: React.FC = () => {
                       type='checkbox'
                       className='sr-only peer'
                       checked={enableAutoNextEpisode}
-                      onChange={(e) => handleEnableAutoNextEpisodeToggle(e.target.checked)}
+                      onChange={(e) =>
+                        handleEnableAutoNextEpisodeToggle(e.target.checked)
+                      }
                     />
                     <div className='w-11 h-6 bg-gray-300 rounded-full peer-checked:bg-green-500 transition-colors dark:bg-gray-600'></div>
                     <div className='absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform peer-checked:translate-x-5'></div>
@@ -1529,7 +1658,8 @@ export const UserMenu: React.FC = () => {
 
               {/* 提示信息 */}
               <div className='text-xs text-gray-500 dark:text-gray-400 bg-blue-50 dark:bg-blue-900/20 p-3 rounded-lg border border-blue-200 dark:border-blue-800'>
-                💡 这些设置会作为新视频的默认配置。对于已配置的视频，请在播放页面的"跳过设置"中单独调整。
+                💡
+                这些设置会作为新视频的默认配置。对于已配置的视频，请在播放页面的"跳过设置"中单独调整。
               </div>
             </div>
 
@@ -1553,7 +1683,11 @@ export const UserMenu: React.FC = () => {
                       type='checkbox'
                       className='sr-only peer'
                       checked={enableContinueWatchingFilter}
-                      onChange={(e) => handleEnableContinueWatchingFilterToggle(e.target.checked)}
+                      onChange={(e) =>
+                        handleEnableContinueWatchingFilterToggle(
+                          e.target.checked
+                        )
+                      }
                     />
                     <div className='w-11 h-6 bg-gray-300 rounded-full peer-checked:bg-green-500 transition-colors dark:bg-gray-600'></div>
                     <div className='absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform peer-checked:translate-x-5'></div>
@@ -1583,7 +1717,10 @@ export const UserMenu: React.FC = () => {
                         className='w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500 transition-all duration-200 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100'
                         value={continueWatchingMinProgress}
                         onChange={(e) => {
-                          const value = Math.max(0, Math.min(100, parseInt(e.target.value) || 0));
+                          const value = Math.max(
+                            0,
+                            Math.min(100, parseInt(e.target.value) || 0)
+                          );
                           handleContinueWatchingMinProgressChange(value);
                         }}
                       />
@@ -1601,7 +1738,10 @@ export const UserMenu: React.FC = () => {
                         className='w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500 transition-all duration-200 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100'
                         value={continueWatchingMaxProgress}
                         onChange={(e) => {
-                          const value = Math.max(0, Math.min(100, parseInt(e.target.value) || 100));
+                          const value = Math.max(
+                            0,
+                            Math.min(100, parseInt(e.target.value) || 100)
+                          );
                           handleContinueWatchingMaxProgressChange(value);
                         }}
                       />
@@ -1610,7 +1750,8 @@ export const UserMenu: React.FC = () => {
 
                   {/* 当前范围提示 */}
                   <div className='text-xs text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 p-3 rounded-lg'>
-                    当前设置：显示播放进度在 {continueWatchingMinProgress}% - {continueWatchingMaxProgress}% 之间的内容
+                    当前设置：显示播放进度在 {continueWatchingMinProgress}% -{' '}
+                    {continueWatchingMaxProgress}% 之间的内容
                   </div>
                 </>
               )}
@@ -1656,9 +1797,7 @@ export const UserMenu: React.FC = () => {
       />
 
       {/* 修改密码面板 */}
-      <div
-        className='fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-md bg-white dark:bg-gray-900 rounded-xl shadow-xl z-[1001] overflow-hidden'
-      >
+      <div className='fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-md bg-white dark:bg-gray-900 rounded-xl shadow-xl z-[1001] overflow-hidden'>
         {/* 内容容器 - 独立的滚动区域 */}
         <div
           className='h-full p-6'
@@ -1773,9 +1912,7 @@ export const UserMenu: React.FC = () => {
       />
 
       {/* 更新弹窗 */}
-      <div
-        className='fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-4xl max-h-[90vh] bg-white dark:bg-gray-900 rounded-xl shadow-xl z-[1001] flex flex-col'
-      >
+      <div className='fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-4xl max-h-[90vh] bg-white dark:bg-gray-900 rounded-xl shadow-xl z-[1001] flex flex-col'>
         {/* 内容容器 - 独立的滚动区域 */}
         <div
           className='flex-1 p-6 overflow-y-auto'
@@ -1823,50 +1960,60 @@ export const UserMenu: React.FC = () => {
               </div>
             )}
             {/* 有新集数的剧集 */}
-            {watchingUpdates && watchingUpdates.updatedSeries.filter(series => series.hasNewEpisode).length > 0 && (
-              <div>
-                <div className='flex items-center gap-2 mb-4'>
-                  <h4 className='text-lg font-semibold text-gray-900 dark:text-white'>
-                    新集更新
-                  </h4>
-                  <div className='flex items-center gap-1'>
-                    <div className='w-2 h-2 bg-red-500 rounded-full animate-pulse'></div>
-                    <span className='text-sm text-red-500 font-medium'>
-                      {watchingUpdates.updatedSeries.filter(series => series.hasNewEpisode).length}部剧集有更新
-                    </span>
+            {watchingUpdates &&
+              watchingUpdates.updatedSeries.filter(
+                (series) => series.hasNewEpisode
+              ).length > 0 && (
+                <div>
+                  <div className='flex items-center gap-2 mb-4'>
+                    <h4 className='text-lg font-semibold text-gray-900 dark:text-white'>
+                      新集更新
+                    </h4>
+                    <div className='flex items-center gap-1'>
+                      <div className='w-2 h-2 bg-red-500 rounded-full animate-pulse'></div>
+                      <span className='text-sm text-red-500 font-medium'>
+                        {
+                          watchingUpdates.updatedSeries.filter(
+                            (series) => series.hasNewEpisode
+                          ).length
+                        }
+                        部剧集有更新
+                      </span>
+                    </div>
+                  </div>
+
+                  <div className='grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4'>
+                    {watchingUpdates.updatedSeries
+                      .filter((series) => series.hasNewEpisode)
+                      .map((series, index) => (
+                        <div
+                          key={`new-${series.title}_${series.year}_${index}`}
+                          className='relative group/card'
+                        >
+                          <div className='relative group-hover/card:z-[5] transition-all duration-300'>
+                            <VideoCard
+                              title={series.title}
+                              poster={series.cover}
+                              year={series.year}
+                              source={series.sourceKey}
+                              source_name={series.source_name}
+                              episodes={series.totalEpisodes}
+                              currentEpisode={series.currentEpisode}
+                              id={series.videoId}
+                              onDelete={undefined}
+                              type={series.totalEpisodes > 1 ? 'tv' : ''}
+                              from='playrecord'
+                            />
+                          </div>
+                          {/* 新集数徽章 */}
+                          <div className='absolute -top-2 -right-2 bg-gradient-to-r from-red-500 to-pink-500 text-white text-xs px-2 py-1 rounded-full shadow-lg z-10'>
+                            +{series.newEpisodes}集
+                          </div>
+                        </div>
+                      ))}
                   </div>
                 </div>
-
-                <div className='grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4'>
-                  {watchingUpdates.updatedSeries
-                    .filter(series => series.hasNewEpisode)
-                    .map((series, index) => (
-                      <div key={`new-${series.title}_${series.year}_${index}`} className='relative group/card'>
-                        <div className='relative group-hover/card:z-[5] transition-all duration-300'>
-                          <VideoCard
-                            title={series.title}
-                            poster={series.cover}
-                            year={series.year}
-                            source={series.sourceKey}
-                            source_name={series.source_name}
-                            episodes={series.totalEpisodes}
-                            currentEpisode={series.currentEpisode}
-                            id={series.videoId}
-                            onDelete={undefined}
-                            type={series.totalEpisodes > 1 ? 'tv' : ''}
-                            from="playrecord"
-                          />
-                        </div>
-                        {/* 新集数徽章 */}
-                        <div className='absolute -top-2 -right-2 bg-gradient-to-r from-red-500 to-pink-500 text-white text-xs px-2 py-1 rounded-full shadow-lg z-10'>
-                          +{series.newEpisodes}集
-                        </div>
-                      </div>
-                    ))}
-                </div>
-              </div>
-            )}
-
+              )}
           </div>
 
           {/* 底部说明 */}
@@ -1954,7 +2101,9 @@ export const UserMenu: React.FC = () => {
                         <div className='flex-1 bg-gray-600 rounded-full h-1'>
                           <div
                             className='bg-blue-500 h-1 rounded-full transition-all'
-                            style={{ width: `${Math.min(getProgress(record), 100)}%` }}
+                            style={{
+                              width: `${Math.min(getProgress(record), 100)}%`,
+                            }}
                           />
                         </div>
                         <span className='text-xs text-white font-medium'>
@@ -1972,12 +2121,13 @@ export const UserMenu: React.FC = () => {
           {playRecords.length === 0 && (
             <div className='text-center py-12'>
               <PlayCircle className='w-16 h-16 text-gray-300 dark:text-gray-600 mx-auto mb-4' />
-              <p className='text-gray-500 dark:text-gray-400 mb-2'>暂无需要继续观看的内容</p>
+              <p className='text-gray-500 dark:text-gray-400 mb-2'>
+                暂无需要继续观看的内容
+              </p>
               <p className='text-xs text-gray-400 dark:text-gray-500'>
                 {enableContinueWatchingFilter
                   ? `观看进度在${continueWatchingMinProgress}%-${continueWatchingMaxProgress}%之间且播放时间超过2分钟的内容会显示在这里`
-                  : '播放时间超过2分钟的所有内容都会显示在这里'
-                }
+                  : '播放时间超过2分钟的所有内容都会显示在这里'}
               </p>
             </div>
           )}
@@ -2043,7 +2193,10 @@ export const UserMenu: React.FC = () => {
                 const today = new Date();
                 today.setHours(0, 0, 0, 0);
                 const releaseDate = new Date(favorite.releaseDate);
-                const daysDiff = Math.ceil((releaseDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+                const daysDiff = Math.ceil(
+                  (releaseDate.getTime() - today.getTime()) /
+                    (1000 * 60 * 60 * 24)
+                );
 
                 // 根据天数差异动态更新显示文字
                 if (daysDiff < 0) {
@@ -2128,7 +2281,8 @@ export const UserMenu: React.FC = () => {
           <User className='w-full h-full relative z-10 group-hover:scale-110 transition-transform duration-300' />
         </button>
         {/* 统一更新提醒点：版本更新或剧集更新都显示橙色点 */}
-        {((updateStatus === UpdateStatus.HAS_UPDATE) || (hasUnreadUpdates && totalUpdates > 0)) && (
+        {(updateStatus === UpdateStatus.HAS_UPDATE ||
+          (hasUnreadUpdates && totalUpdates > 0)) && (
           <div className='absolute top-[2px] right-[2px] w-2 h-2 bg-yellow-500 rounded-full animate-pulse shadow-lg shadow-yellow-500/50'></div>
         )}
       </div>

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -30,7 +30,7 @@ interface ConfigFileStruct {
   }[];
   lives?: {
     [key: string]: LiveCfg;
-  }
+  };
 }
 
 export const API_CONFIG = {
@@ -55,7 +55,6 @@ export const API_CONFIG = {
 
 // 在模块加载时根据环境决定配置来源
 let cachedConfig: AdminConfig;
-
 
 // 从配置文件补充管理员配置
 export function refineConfig(adminConfig: AdminConfig): AdminConfig {
@@ -182,15 +181,18 @@ export function refineConfig(adminConfig: AdminConfig): AdminConfig {
   return adminConfig;
 }
 
-async function getInitConfig(configFile: string, subConfig: {
-  URL: string;
-  AutoUpdate: boolean;
-  LastCheck: string;
-} = {
-    URL: "",
+async function getInitConfig(
+  configFile: string,
+  subConfig: {
+    URL: string;
+    AutoUpdate: boolean;
+    LastCheck: string;
+  } = {
+    URL: '',
     AutoUpdate: false,
-    LastCheck: "",
-  }): Promise<AdminConfig> {
+    LastCheck: '',
+  }
+): Promise<AdminConfig> {
   let cfgFile: ConfigFileStruct;
   try {
     cfgFile = JSON.parse(configFile) as ConfigFileStruct;
@@ -208,8 +210,7 @@ async function getInitConfig(configFile: string, subConfig: {
       SearchDownstreamMaxPage:
         Number(process.env.NEXT_PUBLIC_SEARCH_MAX_PAGE) || 5,
       SiteInterfaceCacheTime: cfgFile.cache_time || 7200,
-      DoubanProxyType:
-        process.env.NEXT_PUBLIC_DOUBAN_PROXY_TYPE || 'direct',
+      DoubanProxyType: process.env.NEXT_PUBLIC_DOUBAN_PROXY_TYPE || 'direct',
       DoubanProxy: process.env.NEXT_PUBLIC_DOUBAN_PROXY || '',
       DoubanImageProxyType:
         process.env.NEXT_PUBLIC_DOUBAN_IMAGE_PROXY_TYPE || 'direct',
@@ -217,8 +218,7 @@ async function getInitConfig(configFile: string, subConfig: {
       DisableYellowFilter:
         process.env.NEXT_PUBLIC_DISABLE_YELLOW_FILTER === 'true',
       ShowAdultContent: false, // 默认不显示成人内容，可在管理面板修改
-      FluidSearch:
-        process.env.NEXT_PUBLIC_FLUID_SEARCH !== 'false',
+      FluidSearch: process.env.NEXT_PUBLIC_FLUID_SEARCH !== 'false',
       // TMDB配置默认值
       TMDBApiKey: process.env.TMDB_API_KEY || '',
       TMDBLanguage: 'zh-CN',
@@ -240,11 +240,13 @@ async function getInitConfig(configFile: string, subConfig: {
   } catch (e) {
     console.error('获取用户列表失败:', e);
   }
-  const allUsers = userNames.filter((u) => u !== process.env.USERNAME).map((u) => ({
-    username: u,
-    role: 'user',
-    banned: false,
-  }));
+  const allUsers = userNames
+    .filter((u) => u !== process.env.USERNAME)
+    .map((u) => ({
+      username: u,
+      role: 'user',
+      banned: false,
+    }));
   allUsers.unshift({
     username: process.env.USERNAME!,
     role: 'owner',
@@ -311,7 +313,7 @@ export async function getConfig(): Promise<AdminConfig> {
 
   // db 中无配置，执行一次初始化
   if (!adminConfig) {
-    adminConfig = await getInitConfig("");
+    adminConfig = await getInitConfig('');
   }
   adminConfig = await configSelfCheck(adminConfig);
   cachedConfig = adminConfig;
@@ -324,12 +326,17 @@ export function clearConfigCache(): void {
   cachedConfig = null as any;
 }
 
-export async function configSelfCheck(adminConfig: AdminConfig): Promise<AdminConfig> {
+export async function configSelfCheck(
+  adminConfig: AdminConfig
+): Promise<AdminConfig> {
   // 确保必要的属性存在和初始化
   if (!adminConfig.UserConfig) {
     adminConfig.UserConfig = { AllowRegister: true, Users: [] };
   }
-  if (!adminConfig.UserConfig.Users || !Array.isArray(adminConfig.UserConfig.Users)) {
+  if (
+    !adminConfig.UserConfig.Users ||
+    !Array.isArray(adminConfig.UserConfig.Users)
+  ) {
     adminConfig.UserConfig.Users = [];
   }
 
@@ -339,9 +346,11 @@ export async function configSelfCheck(adminConfig: AdminConfig): Promise<AdminCo
     const ownerUser = process.env.USERNAME;
 
     // 创建用户列表：保留数据库中存在的用户的配置信息
-    const updatedUsers = dbUsers.map(username => {
+    const updatedUsers = dbUsers.map((username) => {
       // 查找现有配置中是否有这个用户
-      const existingUserConfig = adminConfig.UserConfig.Users.find(u => u.username === username);
+      const existingUserConfig = adminConfig.UserConfig.Users.find(
+        (u) => u.username === username
+      );
 
       if (existingUserConfig) {
         // 保留现有配置
@@ -366,47 +375,83 @@ export async function configSelfCheck(adminConfig: AdminConfig): Promise<AdminCo
   if (adminConfig.UserConfig.AllowRegister === undefined) {
     adminConfig.UserConfig.AllowRegister = true;
   }
+
+  // 确保 SiteConfig 存在
+  if (!adminConfig.SiteConfig) {
+    adminConfig.SiteConfig = {
+      SiteName: process.env.NEXT_PUBLIC_SITE_NAME || 'MoonTV',
+      Announcement: process.env.ANNOUNCEMENT || '',
+      DoubanProxyType:
+        (process.env.NEXT_PUBLIC_DOUBAN_PROXY_TYPE as any) ||
+        'cmliussss-cdn-tencent',
+      DoubanProxy: process.env.NEXT_PUBLIC_DOUBAN_PROXY || '',
+      DoubanImageProxyType:
+        (process.env.NEXT_PUBLIC_DOUBAN_IMAGE_PROXY_TYPE as any) ||
+        'cmliussss-cdn-tencent',
+      DoubanImageProxy: process.env.NEXT_PUBLIC_DOUBAN_IMAGE_PROXY || '',
+      DisableYellowFilter:
+        process.env.NEXT_PUBLIC_DISABLE_YELLOW_FILTER === 'true',
+      SearchMaxPage: parseInt(
+        process.env.NEXT_PUBLIC_SEARCH_MAX_PAGE || '5',
+        10
+      ),
+      FluidSearch: process.env.NEXT_PUBLIC_FLUID_SEARCH !== 'false',
+      TMDBApiKey: process.env.TMDB_API_KEY || '',
+      TMDBLanguage: 'zh-CN',
+      EnableTMDBActorSearch: false,
+    };
+  }
+
   if (!adminConfig.SourceConfig || !Array.isArray(adminConfig.SourceConfig)) {
     adminConfig.SourceConfig = [];
   }
-  if (!adminConfig.CustomCategories || !Array.isArray(adminConfig.CustomCategories)) {
+  if (
+    !adminConfig.CustomCategories ||
+    !Array.isArray(adminConfig.CustomCategories)
+  ) {
     adminConfig.CustomCategories = [];
   }
   if (!adminConfig.LiveConfig || !Array.isArray(adminConfig.LiveConfig)) {
     adminConfig.LiveConfig = [];
   }
-  
+
   // 确保网盘搜索配置有默认值
   if (!adminConfig.NetDiskConfig) {
     adminConfig.NetDiskConfig = {
-      enabled: true,                                    // 默认启用
-      pansouUrl: 'https://so.252035.xyz',               // 默认公益服务
-      timeout: 30,                                      // 默认30秒超时
-      enabledCloudTypes: ['baidu', 'aliyun', 'quark'] // 默认只启用百度、阿里、夸克三大主流网盘
+      enabled: true, // 默认启用
+      pansouUrl: 'https://so.252035.xyz', // 默认公益服务
+      timeout: 30, // 默认30秒超时
+      enabledCloudTypes: ['baidu', 'aliyun', 'quark'], // 默认只启用百度、阿里、夸克三大主流网盘
     };
   }
 
   // 确保AI推荐配置有默认值
   if (!adminConfig.AIRecommendConfig) {
     adminConfig.AIRecommendConfig = {
-      enabled: false,                                   // 默认关闭
-      apiUrl: 'https://api.openai.com/v1',             // 默认OpenAI API
-      apiKey: '',                                       // 默认为空，需要管理员配置
-      model: 'gpt-3.5-turbo',                          // 默认模型
-      temperature: 0.7,                                // 默认温度
-      maxTokens: 3000                                  // 默认最大token数
+      enabled: false, // 默认关闭
+      apiUrl: 'https://api.openai.com/v1', // 默认OpenAI API
+      apiKey: '', // 默认为空，需要管理员配置
+      model: 'gpt-3.5-turbo', // 默认模型
+      temperature: 0.7, // 默认温度
+      maxTokens: 3000, // 默认最大token数
     };
   }
 
   // 确保YouTube配置有默认值
   if (!adminConfig.YouTubeConfig) {
     adminConfig.YouTubeConfig = {
-      enabled: false,                                   // 默认关闭
-      apiKey: '',                                       // 默认为空，需要管理员配置
-      enableDemo: true,                                 // 默认启用演示模式
-      maxResults: 25,                                   // 默认每页25个结果
+      enabled: false, // 默认关闭
+      apiKey: '', // 默认为空，需要管理员配置
+      enableDemo: true, // 默认启用演示模式
+      maxResults: 25, // 默认每页25个结果
       enabledRegions: ['US', 'CN', 'JP', 'KR', 'GB', 'DE', 'FR'], // 默认启用的地区
-      enabledCategories: ['Film & Animation', 'Music', 'Gaming', 'News & Politics', 'Entertainment'] // 默认启用的分类
+      enabledCategories: [
+        'Film & Animation',
+        'Music',
+        'Gaming',
+        'News & Politics',
+        'Entertainment',
+      ], // 默认启用的分类
     };
   }
 
@@ -423,8 +468,12 @@ export async function configSelfCheck(adminConfig: AdminConfig): Promise<AdminCo
     return true;
   });
   // 过滤站长
-  const originOwnerCfg = adminConfig.UserConfig.Users.find((u) => u.username === ownerUser);
-  adminConfig.UserConfig.Users = adminConfig.UserConfig.Users.filter((user) => user.username !== ownerUser);
+  const originOwnerCfg = adminConfig.UserConfig.Users.find(
+    (u) => u.username === ownerUser
+  );
+  adminConfig.UserConfig.Users = adminConfig.UserConfig.Users.filter(
+    (user) => user.username !== ownerUser
+  );
   // 其他用户不得拥有 owner 权限
   adminConfig.UserConfig.Users.forEach((user) => {
     if (user.role === 'owner') {
@@ -452,13 +501,15 @@ export async function configSelfCheck(adminConfig: AdminConfig): Promise<AdminCo
 
   // 自定义分类去重
   const seenCustomCategoryKeys = new Set<string>();
-  adminConfig.CustomCategories = adminConfig.CustomCategories.filter((category) => {
-    if (seenCustomCategoryKeys.has(category.query + category.type)) {
-      return false;
+  adminConfig.CustomCategories = adminConfig.CustomCategories.filter(
+    (category) => {
+      if (seenCustomCategoryKeys.has(category.query + category.type)) {
+        return false;
+      }
+      seenCustomCategoryKeys.add(category.query + category.type);
+      return true;
     }
-    seenCustomCategoryKeys.add(category.query + category.type);
-    return true;
-  });
+  );
 
   // 直播源去重
   const seenLiveKeys = new Set<string>();
@@ -483,7 +534,10 @@ export async function resetConfig() {
   if (!originConfig) {
     originConfig = {} as AdminConfig;
   }
-  const adminConfig = await getInitConfig(originConfig.ConfigFile, originConfig.ConfigSubscribtion);
+  const adminConfig = await getInitConfig(
+    originConfig.ConfigFile,
+    originConfig.ConfigSubscribtion
+  );
   cachedConfig = adminConfig;
   await db.saveAdminConfig(adminConfig);
 
@@ -510,18 +564,26 @@ export async function getAvailableApiSites(user?: string): Promise<ApiSite[]> {
         showAdultContent = userConfig.showAdultContent;
       }
       // 如果用户没有设置，检查用户组设置
-      else if (userConfig.tags && userConfig.tags.length > 0 && config.UserConfig.Tags) {
+      else if (
+        userConfig.tags &&
+        userConfig.tags.length > 0 &&
+        config.UserConfig.Tags
+      ) {
         // 如果用户有多个用户组，只要有一个用户组允许就允许（取并集）
-        const hasAnyTagAllowAdult = userConfig.tags.some(tagName => {
-          const tagConfig = config.UserConfig.Tags?.find(t => t.name === tagName);
+        const hasAnyTagAllowAdult = userConfig.tags.some((tagName) => {
+          const tagConfig = config.UserConfig.Tags?.find(
+            (t) => t.name === tagName
+          );
           return tagConfig?.showAdultContent === true;
         });
         if (hasAnyTagAllowAdult) {
           showAdultContent = true;
         } else {
           // 检查是否有任何用户组明确禁止
-          const hasAnyTagDenyAdult = userConfig.tags.some(tagName => {
-            const tagConfig = config.UserConfig.Tags?.find(t => t.name === tagName);
+          const hasAnyTagDenyAdult = userConfig.tags.some((tagName) => {
+            const tagConfig = config.UserConfig.Tags?.find(
+              (t) => t.name === tagName
+            );
             return tagConfig?.showAdultContent === false;
           });
           if (hasAnyTagDenyAdult) {
@@ -551,12 +613,14 @@ export async function getAvailableApiSites(user?: string): Promise<ApiSite[]> {
   // 优先根据用户自己的 enabledApis 配置查找
   if (userConfig.enabledApis && userConfig.enabledApis.length > 0) {
     const userApiSitesSet = new Set(userConfig.enabledApis);
-    return allApiSites.filter((s) => userApiSitesSet.has(s.key)).map((s) => ({
-      key: s.key,
-      name: s.name,
-      api: s.api,
-      detail: s.detail,
-    }));
+    return allApiSites
+      .filter((s) => userApiSitesSet.has(s.key))
+      .map((s) => ({
+        key: s.key,
+        name: s.name,
+        api: s.api,
+        detail: s.detail,
+      }));
   }
 
   // 如果没有 enabledApis 配置，则根据 tags 查找
@@ -564,20 +628,24 @@ export async function getAvailableApiSites(user?: string): Promise<ApiSite[]> {
     const enabledApisFromTags = new Set<string>();
 
     // 遍历用户的所有 tags，收集对应的 enabledApis
-    userConfig.tags.forEach(tagName => {
-      const tagConfig = config.UserConfig.Tags?.find(t => t.name === tagName);
+    userConfig.tags.forEach((tagName) => {
+      const tagConfig = config.UserConfig.Tags?.find((t) => t.name === tagName);
       if (tagConfig && tagConfig.enabledApis) {
-        tagConfig.enabledApis.forEach(apiKey => enabledApisFromTags.add(apiKey));
+        tagConfig.enabledApis.forEach((apiKey) =>
+          enabledApisFromTags.add(apiKey)
+        );
       }
     });
 
     if (enabledApisFromTags.size > 0) {
-      return allApiSites.filter((s) => enabledApisFromTags.has(s.key)).map((s) => ({
-        key: s.key,
-        name: s.name,
-        api: s.api,
-        detail: s.detail,
-      }));
+      return allApiSites
+        .filter((s) => enabledApisFromTags.has(s.key))
+        .map((s) => ({
+          key: s.key,
+          name: s.name,
+          api: s.api,
+          detail: s.detail,
+        }));
     }
   }
 
@@ -602,8 +670,10 @@ export async function hasSpecialFeaturePermission(
     }
 
     // 使用提供的配置或获取新配置
-    const config = providedConfig || await getConfig();
-    const userConfig = config.UserConfig.Users.find((u) => u.username === username);
+    const config = providedConfig || (await getConfig());
+    const userConfig = config.UserConfig.Users.find(
+      (u) => u.username === username
+    );
 
     // 如果用户不在配置中，检查是否是新注册用户
     if (!userConfig) {
@@ -624,10 +694,20 @@ export async function hasSpecialFeaturePermission(
     }
 
     // 如果没有直接配置，检查用户组 tags 的权限
-    if (userConfig.tags && userConfig.tags.length > 0 && config.UserConfig.Tags) {
+    if (
+      userConfig.tags &&
+      userConfig.tags.length > 0 &&
+      config.UserConfig.Tags
+    ) {
       for (const tagName of userConfig.tags) {
-        const tagConfig = config.UserConfig.Tags.find(t => t.name === tagName);
-        if (tagConfig && tagConfig.enabledApis && tagConfig.enabledApis.includes(feature)) {
+        const tagConfig = config.UserConfig.Tags.find(
+          (t) => t.name === tagName
+        );
+        if (
+          tagConfig &&
+          tagConfig.enabledApis &&
+          tagConfig.enabledApis.includes(feature)
+        ) {
           return true;
         }
       }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -128,13 +128,17 @@ export interface IStorage {
     config: EpisodeSkipConfig
   ): Promise<void>;
   deleteSkipConfig(userName: string, source: string, id: string): Promise<void>;
-  getAllSkipConfigs(userName: string): Promise<{ [key: string]: EpisodeSkipConfig }>;
+  getAllSkipConfigs(
+    userName: string
+  ): Promise<{ [key: string]: EpisodeSkipConfig }>;
 
   // 数据清理相关
   clearAllData(): Promise<void>;
 
   // 通用缓存相关（新增）
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   getCache(key: string): Promise<any | null>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   setCache(key: string, data: any, expireSeconds?: number): Promise<void>;
   deleteCache(key: string): Promise<void>;
   clearExpiredCache(prefix?: string): Promise<void>;
@@ -225,6 +229,20 @@ export interface EpisodeSkipConfig {
   updated_time: number; // 最后更新时间
 }
 
+// 直播观看记录数据结构
+export interface LiveViewRecord {
+  username: string; // 用户名
+  channelName: string; // 频道名称
+  channelId: string; // 频道ID
+  sourceName: string; // 直播源名称
+  sourceKey: string; // 直播源key
+  startTime: number; // 开始观看时间戳
+  endTime: number; // 结束观看时间戳
+  duration: number; // 观看时长（秒）
+  channelGroup?: string; // 频道分组
+  channelLogo?: string; // 频道logo
+}
+
 // 用户播放统计数据结构
 export interface UserPlayStat {
   username: string; // 用户名
@@ -311,6 +329,41 @@ export interface ContentStat {
   averageWatchTime: number; // 平均观看时长
   lastPlayed: number; // 最后播放时间
   uniqueUsers: number; // 观看用户数
+}
+
+// 直播统计结果数据结构
+export interface LiveStatsResult {
+  totalUsers: number; // 总用户数
+  totalWatchTime: number; // 总观看时长（秒）
+  totalViews: number; // 总观看次数
+  avgWatchTimePerUser: number; // 用户平均观看时长
+  avgViewsPerUser: number; // 用户平均观看次数
+  userStats: Array<{
+    username: string;
+    totalWatchTime: number;
+    totalViews: number;
+    lastViewTime: number;
+    recentRecords: LiveViewRecord[];
+    avgWatchTime: number;
+    mostWatchedChannel: string;
+    mostWatchedSource: string;
+  }>;
+  topChannels: Array<{
+    channelName: string;
+    channelId: string;
+    viewCount: number;
+    totalWatchTime: number;
+  }>;
+  topSources: Array<{
+    sourceName: string;
+    sourceKey: string;
+    viewCount: number;
+  }>;
+  dailyStats: Array<{
+    date: string;
+    watchTime: number;
+    views: number;
+  }>;
 }
 
 // 发布日历数据结构


### PR DESCRIPTION
新增功能:
- 添加直播观看记录追踪功能,自动记录用户观看直播的时长和频道信息
- 新增直播统计页面 (/admin/live-stats),展示用户观看统计、热门频道、热门直播源等数据
- 在用户菜单中添加"直播统计"入口,方便管理员访问

修复问题:
- 修复直播统计API的用户查询限制,移除100用户上限,确保所有用户数据都能正确显示
- 修复 SiteConfig 未定义导致的配置加载错误,添加默认值检查

技术细节:
- 使用 Redis 存储直播观看记录 (live_views:{username})
- 观看时长超过5秒才会被记录
- 支持页面切换和关闭时自动保存观看记录
- 统计数据包括总观看时长、观看次数、热门频道、热门直播源、每日统计等

🤖 Generated with [Claude Code](https://claude.com/claude-code)