### PR TITLE
perf: only send AI recommendation requests when enabled by a backend toggle

### DIFF
--- a/src/app/douban/page.tsx
+++ b/src/app/douban/page.tsx
@@ -7,6 +7,7 @@ import { useSearchParams } from 'next/navigation';
 import { Suspense } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { isAIRecommendFeatureDisabled } from '@/lib/ai-recommend.client';
 import { GetBangumiCalendarData } from '@/lib/bangumi.client';
 import {
   getDoubanCategories,
@@ -129,6 +130,12 @@ function DoubanPageClient() {
 
   // 页面级别的AI权限检测 - 只检测一次
   useEffect(() => {
+    if (isAIRecommendFeatureDisabled()) {
+      setAiEnabled(false);
+      setAiCheckComplete(true);
+      return;
+    }
+
     let cancelled = false;
     (async () => {
       try {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -68,6 +68,7 @@ export default async function RootLayout({
     process.env.NEXT_PUBLIC_DISABLE_YELLOW_FILTER === 'true';
   let fluidSearch = process.env.NEXT_PUBLIC_FLUID_SEARCH !== 'false';
   let customAdFilterVersion = 0;
+  let aiRecommendEnabled = false;
   let customCategories = [] as {
     name: string;
     type: 'movie' | 'tv';
@@ -92,6 +93,7 @@ export default async function RootLayout({
     }));
     fluidSearch = config.SiteConfig.FluidSearch;
     customAdFilterVersion = config.SiteConfig?.CustomAdFilterVersion || 0;
+    aiRecommendEnabled = config.AIRecommendConfig?.enabled ?? false;
   }
 
   // 将运行时配置注入到全局 window 对象，供客户端在运行时读取
@@ -105,6 +107,7 @@ export default async function RootLayout({
     CUSTOM_CATEGORIES: customCategories,
     FLUID_SEARCH: fluidSearch,
     CUSTOM_AD_FILTER_VERSION: customAdFilterVersion,
+    AI_RECOMMEND_ENABLED: aiRecommendEnabled,
   };
 
   return (

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -3,6 +3,8 @@
 import { Sparkles } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
+import { isAIRecommendFeatureDisabled } from '@/lib/ai-recommend.client';
+
 import AIRecommendModal from './AIRecommendModal';
 import { BackButton } from './BackButton';
 import MobileBottomNav from './MobileBottomNav';
@@ -32,6 +34,11 @@ const PageLayout = ({
 
   // 检查 AI 功能是否开启
   useEffect(() => {
+    if (isAIRecommendFeatureDisabled()) {
+      setAiEnabled(false);
+      return;
+    }
+
     let cancelled = false;
 
     (async () => {

--- a/src/components/ShortDramaCard.tsx
+++ b/src/components/ShortDramaCard.tsx
@@ -7,16 +7,7 @@ import { useRouter } from 'next/navigation';
 import { memo, useEffect, useState, useCallback } from 'react';
 
 import { useLongPress } from '@/hooks/useLongPress';
-import MobileActionSheet from '@/components/MobileActionSheet';
-import AIRecommendModal from '@/components/AIRecommendModal';
-
-import { ShortDramaItem } from '@/lib/types';
-import {
-  SHORTDRAMA_CACHE_EXPIRE,
-  getCacheKey,
-  getCache,
-  setCache,
-} from '@/lib/shortdrama-cache';
+import { isAIRecommendFeatureDisabled } from '@/lib/ai-recommend.client';
 import {
   isFavorited,
   saveFavorite,
@@ -24,6 +15,16 @@ import {
   generateStorageKey,
   subscribeToDataUpdates,
 } from '@/lib/db.client';
+import {
+  SHORTDRAMA_CACHE_EXPIRE,
+  getCacheKey,
+  getCache,
+  setCache,
+} from '@/lib/shortdrama-cache';
+import { ShortDramaItem } from '@/lib/types';
+
+import AIRecommendModal from '@/components/AIRecommendModal';
+import MobileActionSheet from '@/components/MobileActionSheet';
 
 interface ShortDramaCardProps {
   drama: ShortDramaItem;
@@ -48,7 +49,7 @@ function ShortDramaCard({
 
   // AI功能状态：优先使用父组件传递的值，否则自己检测
   const [aiEnabledLocal, setAiEnabledLocal] = useState(false);
-  const [aiCheckCompleteLocal, setAiCheckCompleteLocal] = useState(false);
+  const [, setAiCheckCompleteLocal] = useState(false);
 
   // 实际使用的AI状态（优先父组件prop）
   const aiEnabled = aiEnabledProp !== undefined ? aiEnabledProp : aiEnabledLocal;
@@ -87,6 +88,12 @@ function ShortDramaCard({
   useEffect(() => {
     // 如果父组件已传递aiEnabled，跳过本地检测
     if (aiEnabledProp !== undefined) {
+      return;
+    }
+
+    if (isAIRecommendFeatureDisabled()) {
+      setAiEnabledLocal(false);
+      setAiCheckCompleteLocal(true);
       return;
     }
 

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -14,6 +14,8 @@ import React, {
   useState,
 } from 'react';
 
+import { useLongPress } from '@/hooks/useLongPress';
+import { isAIRecommendFeatureDisabled } from '@/lib/ai-recommend.client';
 import {
   deleteFavorite,
   deletePlayRecord,
@@ -23,7 +25,6 @@ import {
   subscribeToDataUpdates,
 } from '@/lib/db.client';
 import { processImageUrl, isSeriesCompleted } from '@/lib/utils';
-import { useLongPress } from '@/hooks/useLongPress';
 
 import { ImagePlaceholder } from '@/components/ImagePlaceholder';
 import MobileActionSheet from '@/components/MobileActionSheet';
@@ -213,6 +214,12 @@ const VideoCard = forwardRef<VideoCardHandle, VideoCardProps>(function VideoCard
   useEffect(() => {
     // 如果父组件已传递aiEnabled，跳过本地检测
     if (aiEnabledProp !== undefined || aiCheckCompleteProp !== undefined) {
+      return;
+    }
+
+    if (isAIRecommendFeatureDisabled()) {
+      setAiEnabledLocal(false);
+      setAiCheckCompleteLocal(true);
       return;
     }
 

--- a/src/lib/ai-recommend.client.ts
+++ b/src/lib/ai-recommend.client.ts
@@ -44,6 +44,15 @@ export interface AIRecommendHistory {
   response: string;
 }
 
+export function isAIRecommendFeatureDisabled(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  const runtimeConfig = (window as any).RUNTIME_CONFIG;
+  return runtimeConfig?.AI_RECOMMEND_ENABLED === false;
+}
+
 /**
  * 发送AI推荐请求（支持流式响应）
  */
@@ -181,6 +190,10 @@ export async function getAIRecommendHistory(): Promise<{
  * 检查AI推荐功能是否可用
  */
 export async function checkAIRecommendAvailable(): Promise<boolean> {
+  if (isAIRecommendFeatureDisabled()) {
+    return false;
+  }
+
   try {
     const response = await fetch('/api/ai-recommend', {
       method: 'POST',


### PR DESCRIPTION
优化控制面板中关闭AI功能后，前端不自动发起ai-recommend请求