### PR TITLE
fix: 修正快进快退按钮图标方向

### DIFF
--- a/src/lib/artplayer-plugin-seek-buttons.js
+++ b/src/lib/artplayer-plugin-seek-buttons.js
@@ -21,18 +21,33 @@ export default function artplayerPluginSeekButtons(option = {}) {
     // 检测屏幕宽度
     const isSmallScreen = () => window.innerWidth < 768;
 
+    const backwardIconPath = 'M16 4c6.627 0 12 5.373 12 12s-5.373 12-12 12S4 22.627 4 16h2.5c0 5.247 4.253 9.5 9.5 9.5s9.5-4.253 9.5-9.5S21.247 6.5 16 6.5c-2.858 0-5.42 1.265-7.176 3.265L12 13H4V5l2.94 2.94C9.303 5.39 12.453 4 16 4z';
+    const forwardIconPath = 'M16 4C9.373 4 4 9.373 4 16s5.373 12 12 12 12-5.373 12-12h-2.5c0 5.247-4.253 9.5-9.5 9.5S6.5 21.247 6.5 16 10.753 6.5 16 6.5c2.858 0 5.42 1.265 7.176 3.265L20 13h8V5l-2.94 2.94C22.697 5.39 19.547 4 16 4z';
+
     // 生成图标的函数
-    const generateBackwardIcon = (time) => `
+    const generateSeekIcon = (path, time) => `
       <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" style="width: 100%; height: 100%;">
-        <path d="M16 4C9.373 4 4 9.373 4 16s5.373 12 12 12 12-5.373 12-12h-2.5c0 5.247-4.253 9.5-9.5 9.5S6.5 21.247 6.5 16 10.753 6.5 16 6.5c2.858 0 5.42 1.265 7.176 3.265L20 13h8V5l-2.94 2.94C22.697 5.39 19.547 4 16 4z" fill="currentColor"/>
+        <path d="${path}" fill="currentColor"/>
         <text x="16" y="19" text-anchor="middle" font-size="9" font-weight="bold" fill="currentColor" font-family="Arial, sans-serif">${time}</text>
       </svg>
     `;
 
-    const generateForwardIcon = (time) => `
-      <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" style="width: 100%; height: 100%;">
-        <path d="M16 4c6.627 0 12 5.373 12 12s-5.373 12-12 12S4 22.627 4 16h2.5c0 5.247 4.253 9.5 9.5 9.5s9.5-4.253 9.5-9.5S21.247 6.5 16 6.5c-2.858 0-5.42 1.265-7.176 3.265L12 13H4V5l2.94 2.94C9.303 5.39 12.453 4 16 4z" fill="currentColor"/>
-        <text x="16" y="19" text-anchor="middle" font-size="9" font-weight="bold" fill="currentColor" font-family="Arial, sans-serif">${time}</text>
+    const generateBackwardIcon = (time) => generateSeekIcon(backwardIconPath, time);
+
+    const generateForwardIcon = (time) => generateSeekIcon(forwardIconPath, time);
+
+    const generateDualSeekIcon = (time) => `
+      <svg viewBox="0 0 32 56" fill="none" xmlns="http://www.w3.org/2000/svg" style="width: 100%; height: 100%;">
+        <!-- 上方后退箭头 -->
+        <g transform="translate(0, 2) scale(0.65)">
+          <path d="${backwardIconPath}" fill="currentColor"/>
+          <text x="16" y="19" text-anchor="middle" font-size="9" font-weight="bold" fill="currentColor" font-family="Arial, sans-serif">${time}</text>
+        </g>
+        <!-- 下方前进箭头 -->
+        <g transform="translate(0, 30) scale(0.65)">
+          <path d="${forwardIconPath}" fill="currentColor"/>
+          <text x="16" y="19" text-anchor="middle" font-size="9" font-weight="bold" fill="currentColor" font-family="Arial, sans-serif">${time}</text>
+        </g>
       </svg>
     `;
 
@@ -64,21 +79,7 @@ export default function artplayerPluginSeekButtons(option = {}) {
 
         if (isSingleButton) {
           // 单侧模式：显示双向箭头（竖向排列）
-          const dualIcon = `
-            <svg viewBox="0 0 32 56" fill="none" xmlns="http://www.w3.org/2000/svg" style="width: 100%; height: 100%;">
-              <!-- 上方后退箭头 -->
-              <g transform="translate(0, 2) scale(0.65)">
-                <path d="M16 4C9.373 4 4 9.373 4 16s5.373 12 12 12 12-5.373 12-12h-2.5c0 5.247-4.253 9.5-9.5 9.5S6.5 21.247 6.5 16 10.753 6.5 16 6.5c2.858 0 5.42 1.265 7.176 3.265L20 13h8V5l-2.94 2.94C22.697 5.39 19.547 4 16 4z" fill="currentColor"/>
-                <text x="16" y="19" text-anchor="middle" font-size="9" font-weight="bold" fill="currentColor" font-family="Arial, sans-serif">${currentSeekTime}</text>
-              </g>
-              <!-- 下方前进箭头 -->
-              <g transform="translate(0, 30) scale(0.65)">
-                <path d="M16 4c6.627 0 12 5.373 12 12s-5.373 12-12 12S4 22.627 4 16h2.5c0 5.247 4.253 9.5 9.5 9.5s9.5-4.253 9.5-9.5S21.247 6.5 16 6.5c-2.858 0-5.42 1.265-7.176 3.265L12 13H4V5l2.94 2.94C9.303 5.39 12.453 4 16 4z" fill="currentColor"/>
-                <text x="16" y="19" text-anchor="middle" font-size="9" font-weight="bold" fill="currentColor" font-family="Arial, sans-serif">${currentSeekTime}</text>
-              </g>
-            </svg>
-          `;
-          button.innerHTML = dualIcon;
+          button.innerHTML = generateDualSeekIcon(currentSeekTime);
 
           // 点击事件：上半边快退，下半边快进
           button.onclick = (e) => {
@@ -366,19 +367,7 @@ export default function artplayerPluginSeekButtons(option = {}) {
 
               if (isSingleButton) {
                 // 单侧模式：显示双向箭头（竖向排列）
-                const dualIcon = `
-                  <svg viewBox="0 0 32 56" fill="none" xmlns="http://www.w3.org/2000/svg" style="width: 100%; height: 100%;">
-                    <g transform="translate(0, 2) scale(0.65)">
-                      <path d="M16 4C9.373 4 4 9.373 4 16s5.373 12 12 12 12-5.373 12-12h-2.5c0 5.247-4.253 9.5-9.5 9.5S6.5 21.247 6.5 16 10.753 6.5 16 6.5c2.858 0 5.42 1.265 7.176 3.265L20 13h8V5l-2.94 2.94C22.697 5.39 19.547 4 16 4z" fill="currentColor"/>
-                      <text x="16" y="19" text-anchor="middle" font-size="9" font-weight="bold" fill="currentColor" font-family="Arial, sans-serif">${currentSeekTime}</text>
-                    </g>
-                    <g transform="translate(0, 30) scale(0.65)">
-                      <path d="M16 4c6.627 0 12 5.373 12 12s-5.373 12-12 12S4 22.627 4 16h2.5c0 5.247 4.253 9.5 9.5 9.5s9.5-4.253 9.5-9.5S21.247 6.5 16 6.5c-2.858 0-5.42 1.265-7.176 3.265L12 13H4V5l2.94 2.94C9.303 5.39 12.453 4 16 4z" fill="currentColor"/>
-                      <text x="16" y="19" text-anchor="middle" font-size="9" font-weight="bold" fill="currentColor" font-family="Arial, sans-serif">${currentSeekTime}</text>
-                    </g>
-                  </svg>
-                `;
-                button.innerHTML = dualIcon;
+                button.innerHTML = generateDualSeekIcon(currentSeekTime);
                 button.onclick = (e) => {
                   const rect = button.getBoundingClientRect();
                   const clickY = e.clientY - rect.top;
@@ -436,19 +425,7 @@ export default function artplayerPluginSeekButtons(option = {}) {
             } else {
               // 单侧模式：更新双向箭头（竖向排列）
               buttons.forEach(button => {
-                const dualIcon = `
-                  <svg viewBox="0 0 32 56" fill="none" xmlns="http://www.w3.org/2000/svg" style="width: 100%; height: 100%;">
-                    <g transform="translate(0, 2) scale(0.65)">
-                      <path d="M16 4C9.373 4 4 9.373 4 16s5.373 12 12 12 12-5.373 12-12h-2.5c0 5.247-4.253 9.5-9.5 9.5S6.5 21.247 6.5 16 10.753 6.5 16 6.5c2.858 0 5.42 1.265 7.176 3.265L20 13h8V5l-2.94 2.94C22.697 5.39 19.547 4 16 4z" fill="currentColor"/>
-                      <text x="16" y="19" text-anchor="middle" font-size="9" font-weight="bold" fill="currentColor" font-family="Arial, sans-serif">${currentSeekTime}</text>
-                    </g>
-                    <g transform="translate(0, 30) scale(0.65)">
-                      <path d="M16 4c6.627 0 12 5.373 12 12s-5.373 12-12 12S4 22.627 4 16h2.5c0 5.247 4.253 9.5 9.5 9.5s9.5-4.253 9.5-9.5S21.247 6.5 16 6.5c-2.858 0-5.42 1.265-7.176 3.265L12 13H4V5l2.94 2.94C9.303 5.39 12.453 4 16 4z" fill="currentColor"/>
-                      <text x="16" y="19" text-anchor="middle" font-size="9" font-weight="bold" fill="currentColor" font-family="Arial, sans-serif">${currentSeekTime}</text>
-                    </g>
-                  </svg>
-                `;
-                button.innerHTML = dualIcon;
+                button.innerHTML = generateDualSeekIcon(currentSeekTime);
               });
             }
           }


### PR DESCRIPTION
修正播放器快进/快退按钮的圆形箭头 SVG 方向，避免“前进 10 秒”显示成后退图标、“后退 10 秒”显示成前进图标。

改动仅影响图标显示，不改变快进/快退逻辑。

当前的图标样式：

<img width="339" height="193" alt="image" src="https://github.com/user-attachments/assets/258aaa1f-aad9-4999-8d3c-8044ce30d7ba" />

<br>参考的图标样式，以 Netflix 为例：

> <img width="505" height="181" alt="image" src="https://github.com/user-attachments/assets/97bf6863-c5ba-466a-87b1-e1546a9dfa62" />
> 
> 左为后退 10 秒，右为前进 10 秒。

修复后的图标样式：

<img width="337" height="167" alt="image" src="https://github.com/user-attachments/assets/7301ce9e-2d2f-48d0-bde1-4b3cc642d7ba" />

