### PR TITLE
修复edgeone部署后访问主页返回 ERR_TOO_MANY_REDIRECTS

### DIFF
--- a/scripts/edgeone-build.mjs
+++ b/scripts/edgeone-build.mjs
@@ -276,20 +276,36 @@ function injectLayoutAuthCheck() {
   const authCheck = `
   // EdgeOne SSR auth guard
   const __h = await headers();
-  let __path = __h.get('x-pathname') || __h.get('x-invoke-path') || '';
-  if (!__path) {
-    const __ref = __h.get('referer') || '';
-    try { if (__ref) __path = new URL(__ref).pathname; } catch {}
+  const __rawPath =
+    __h.get('x-pathname') ||
+    __h.get('x-invoke-path') ||
+    __h.get('x-forwarded-uri') ||
+    __h.get('x-original-uri') ||
+    __h.get('x-original-url') ||
+    __h.get('x-rewrite-url') ||
+    __h.get('next-url') ||
+    __h.get('x-next-url') ||
+    '';
+  let __path = '';
+  let __search = '';
+  if (__rawPath) {
+    try {
+      const __url = new URL(__rawPath, 'http://edgeone.local');
+      __path = __url.pathname;
+      __search = __url.search;
+    } catch {
+      const __queryIndex = __rawPath.indexOf('?');
+      __path = __queryIndex === -1 ? __rawPath : __rawPath.slice(0, __queryIndex);
+      __search = __queryIndex === -1 ? '' : __rawPath.slice(__queryIndex);
+    }
   }
-  if (!__path) __path = '/';
 
   const __skipPaths = ${pageSkipPaths};
-  if (!__skipPaths.some((p) => __path.startsWith(p))) {
+  if (__path && !__skipPaths.some((p) => __path.startsWith(p))) {
     const __cookieStore = await cookies();
     const __authCookie = __cookieStore.get('user_auth') || __cookieStore.get('auth');
     if (!__authCookie) {
-      const __search = __h.get('x-search') || '';
-      redirect('/login?redirect=' + encodeURIComponent(__path + __search));
+      redirect('/login?redirect=' + encodeURIComponent(__path + (__h.get('x-search') || __search)));
     }
   }
 `;


### PR DESCRIPTION
CODEX修复，供参考
症状：访问主页返回 ERR_TOO_MANY_REDIRECTS

根因：edgeone-build.mjs 在构建时向 layout.tsx 的 RootLayout 注入了 SSR 层认证守卫，但该守卫无法在 EdgeOne Pages 的 SSR 环境中正确识别当前请求路径，导致 /login 页面也被重定向到 /login，形成死循环。

详细链路：

EdgeOne Pages 平台上，页面 SSR 请求绕过 edge middleware（构建脚本注释已确认这一点），所以 middleware 中的认证逻辑对页面请求无效。

为弥补此缺陷，构建脚本在 RootLayout 内注入了 SSR 认证守卫，逻辑如下：

__path = headers().get('x-pathname') || headers().get('x-invoke-path') || ''
若为空 → 从 referer 推断 → 仍为空 → 默认值 '/'
若 __path 不在 skipPaths 中 → 检查 auth cookie → 无 cookie → redirect('/login')
关键问题：EdgeOne Pages 的 SSR 请求不携带 x-pathname 或 x-invoke-path 头；首次访问时 referer 也为空。于是 __path 总是回退为 /。

循环触发：

用户访问 / → 守卫判定 __path = '/' → 不在 skipPaths → 无 auth cookie → redirect('/login?redirect=%2F')
浏览器 302 到 /login?redirect=%2F → SSR 再次渲染 → x-pathname 仍空 → referer 为 / → __path = '/' → 不在 skipPaths → 再次 redirect('/login') → 死循环
即使 /login 在 __skipPaths 中，守卫也无法识别当前请求就是 /login，因为路径检测完全依赖不可用的头信息。

涉及文件：

scripts/edgeone-build.mjs — injectLayoutAuthCheck() 函数中的路径检测逻辑
src/app/layout.tsx — 构建时被注入的 SSR 认证守卫